### PR TITLE
Fixing issue where onSourceInstance() is not defined

### DIFF
--- a/examples/shared/base-field-builder/record.jsx
+++ b/examples/shared/base-field-builder/record.jsx
@@ -64,7 +64,7 @@ class Record extends React.Component {
             quip.apps.EventType.ELEMENT_BLUR,
             this.hideFieldPicker);
         if (this.props.entity.isLoggedIn() &&
-            this.props.entity.getClient().onSourceInstance()) {
+            this.props.entity.getClient().getInstanceUrl()) {
             this.props.entity
                 .fetchData()
                 .then(() => {


### PR DESCRIPTION
onSourceInstance() is not defined in the client inside the salesforce-record example.
See Issue #6 