### PR TITLE
Adding support for 3 letter ISO currency codes

### DIFF
--- a/examples/shared/base-field-builder/model/field.js
+++ b/examples/shared/base-field-builder/model/field.js
@@ -365,6 +365,9 @@ export class NumericFieldEntity extends TextFieldEntity {
         }
         const displayValue = this.getOriginalDisplayValue();
         if (typeof displayValue === "string" && displayValue.length > 0) {
+            if (isNaN(parseInt(displayValue.charAt(1)))) {
+              return displayValue.substring(0,3);
+            }
             return displayValue.charAt(0);
         }
         return null;


### PR DESCRIPTION
This is mainly for the Salesforce Record Live App, but could be relevant elsewhere.  

Right now we're just grabbing the first char of currency fields and using that as the symbol.  When you have multiple currencies enabled in a Salesforce org, it uses ISO codes instead of symbols.  

Example: $256,000 vs. U256,000