### PR TITLE
Quip test utils

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.0-alpha.20"
+  "version": "1.0.0-alpha.21"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "npx lerna bootstrap && npx lerna exec -- npm run build --if-present && npx lerna run test"
+      "pre-push": "npm run test"
     }
   },
   "devDependencies": {
@@ -25,6 +25,7 @@
   "scripts": {
     "build": "lerna run build",
     "release": "lerna run build && lerna publish",
-    "release:next": "lerna run build && lerna publish prerelease --dist-tag next"
+    "release:next": "lerna run build && lerna publish prerelease --dist-tag next",
+    "test": "lerna bootstrap && lerna exec -- npm run build --if-present && lerna run test"
   }
 }

--- a/packages/quip-test-utils/.gitignore
+++ b/packages/quip-test-utils/.gitignore
@@ -1,0 +1,3 @@
+# typescript
+
+dist

--- a/packages/quip-test-utils/README.md
+++ b/packages/quip-test-utils/README.md
@@ -1,0 +1,50 @@
+# Quip Test Utils
+
+---
+
+This library contains some helpers intended to make testing Quip live Apps easier.
+
+## Installation:
+
+```
+npm install --save-dev quip-test-utils
+```
+
+## APIs
+
+### `applySnapshot(record: Record, data: SnapshotNode, legacyTypes: RecordPropertyDefinition = {})`
+
+applySnapshot overwrites a record with the deserialized data from `data`, which
+is presumed to be exported via the developer menu from a running live app. It is
+useful when exporting a state that you would like to regression test or
+otherwise write tests around, but would be challenging to manually recreate by
+writing directly to records.
+
+If your old snapshot contains properties that are no longer defined in
+getProperties (e.g. if you're using a snapshot and have since deprecated a
+property), you can pass those properties, as they were originally defined, as
+the last argument.
+
+### `runMigrations(manifest: Manifest, appVersion: number, record: quip.apps.RootRecord)`
+
+runMigrations will apply any relevant migrations for the given app version to
+the record passed. You will likely want to use this in combination with
+applySnapshot and jest snapshots to verify that your migrations perform as
+expected before publishing them:
+
+```javascript
+// src/model/root.test.js
+
+import {RootRecord} from "./root";
+import manifest from "../../manifest.json";
+import recordWithFlipper from "../../test/fixtures/record-with-flipper.json";
+
+test("v42 deprecates the 'flipper' field", () => {
+  const root = new RootRecord();
+  quip.testUtils.applySnapshot(root, recordWithFlipper);
+  expect(root.get("flipper")).toMatchSnapshot();
+  // manifest has a migration defined for version 42 that mutates "flipper"
+  await quip.testUtils.runMigrations(manifest, 42, root);
+  expect(root.get("flipper")).toMatchSnapshot();
+});
+```

--- a/packages/quip-test-utils/package-lock.json
+++ b/packages/quip-test-utils/package-lock.json
@@ -4,118 +4,6 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@babel/code-frame": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-            "dev": true,
-            "requires": {
-                "@babel/highlight": "^7.10.4"
-            }
-        },
-        "@babel/generator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
-            "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.10.4",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.13",
-                "source-map": "^0.5.0"
-            }
-        },
-        "@babel/helper-function-name": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-            "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-get-function-arity": "^7.10.4",
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
-            }
-        },
-        "@babel/helper-get-function-arity": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-            "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.10.4"
-            }
-        },
-        "@babel/helper-split-export-declaration": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-            "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
-            "dev": true,
-            "requires": {
-                "@babel/types": "^7.10.4"
-            }
-        },
-        "@babel/helper-validator-identifier": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-            "dev": true
-        },
-        "@babel/highlight": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "chalk": "^2.0.0",
-                "js-tokens": "^4.0.0"
-            }
-        },
-        "@babel/parser": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
-            "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
-            "dev": true
-        },
-        "@babel/template": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-            "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4"
-            }
-        },
-        "@babel/traverse": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
-            "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
-            "dev": true,
-            "requires": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.10.4",
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4",
-                "@babel/parser": "^7.10.4",
-                "@babel/types": "^7.10.4",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.13"
-            }
-        },
-        "@babel/types": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
-            "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
-            "dev": true,
-            "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.13",
-                "to-fast-properties": "^2.0.0"
-            }
-        },
         "@types/prop-types": {
             "version": "15.7.3",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -132,104 +20,11 @@
                 "csstype": "^2.2.0"
             }
         },
-        "ajv": {
-            "version": "6.12.3",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-            "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
-            "dev": true,
-            "requires": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
-            }
-        },
-        "ansi-regex": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-            "dev": true
-        },
-        "ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "requires": {
-                "color-convert": "^1.9.0"
-            }
-        },
-        "append-transform": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-            "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
-            "dev": true,
-            "requires": {
-                "default-require-extensions": "^2.0.0"
-            }
-        },
-        "archy": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-            "dev": true
-        },
-        "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "asn1": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-            "dev": true,
-            "requires": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-            "dev": true
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-            "dev": true
-        },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-            "dev": true
-        },
-        "aws4": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-            "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
-            "dev": true
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
             "dev": true
-        },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "dev": true,
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -241,175 +36,16 @@
                 "concat-map": "0.0.1"
             }
         },
-        "caching-transform": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
-            "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
-            "dev": true,
-            "requires": {
-                "hasha": "^3.0.0",
-                "make-dir": "^2.0.0",
-                "package-hash": "^3.0.0",
-                "write-file-atomic": "^2.4.2"
-            }
-        },
-        "camelcase": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-            "dev": true
-        },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-            "dev": true
-        },
-        "chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            }
-        },
-        "cliui": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-            "dev": true,
-            "requires": {
-                "string-width": "^3.1.0",
-                "strip-ansi": "^5.2.0",
-                "wrap-ansi": "^5.1.0"
-            }
-        },
-        "color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "requires": {
-                "color-name": "1.1.3"
-            }
-        },
-        "color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
-        "commondir": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-            "dev": true
-        },
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
-        "convert-source-map": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "~5.1.1"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                    "dev": true
-                }
-            }
-        },
-        "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
-        },
-        "coveralls": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
-            "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
-            "dev": true,
-            "requires": {
-                "js-yaml": "^3.13.1",
-                "lcov-parse": "^1.0.0",
-                "log-driver": "^1.2.7",
-                "minimist": "^1.2.5",
-                "request": "^2.88.2"
-            }
-        },
-        "cp-file": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
-            "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "make-dir": "^2.0.0",
-                "nested-error-stacks": "^2.0.0",
-                "pify": "^4.0.1",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "cross-spawn": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-            "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-            "dev": true,
-            "requires": {
-                "lru-cache": "^4.0.1",
-                "which": "^1.2.9"
-            }
-        },
         "csstype": {
             "version": "2.6.11",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
             "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
-            "dev": true
-        },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
-        "debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-            "dev": true,
-            "requires": {
-                "ms": "^2.1.1"
-            }
-        },
-        "decamelize": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
         "deep-equal": {
@@ -424,15 +60,6 @@
                 "object-is": "^1.0.1",
                 "object-keys": "^1.1.1",
                 "regexp.prototype.flags": "^1.2.0"
-            }
-        },
-        "default-require-extensions": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-            "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
-            "dev": true,
-            "requires": {
-                "strip-bom": "^3.0.0"
             }
         },
         "define-properties": {
@@ -450,12 +77,6 @@
             "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
             "dev": true
         },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "dev": true
-        },
         "dotignore": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
@@ -463,31 +84,6 @@
             "dev": true,
             "requires": {
                 "minimatch": "^3.0.4"
-            }
-        },
-        "ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-            "dev": true,
-            "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
-        },
-        "emoji-regex": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-            "dev": true
-        },
-        "error-ex": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-            "dev": true,
-            "requires": {
-                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -531,68 +127,6 @@
                 "is-symbol": "^1.0.2"
             }
         },
-        "es6-error": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-            "dev": true
-        },
-        "escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-            "dev": true
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
-        },
-        "extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-            "dev": true
-        },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-            "dev": true
-        },
-        "fast-deep-equal": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
-        },
-        "find-cache-dir": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-            "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-            "dev": true,
-            "requires": {
-                "commondir": "^1.0.1",
-                "make-dir": "^2.0.0",
-                "pkg-dir": "^3.0.0"
-            }
-        },
-        "find-up": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-            "dev": true,
-            "requires": {
-                "locate-path": "^3.0.0"
-            }
-        },
         "for-each": {
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -600,33 +134,6 @@
             "dev": true,
             "requires": {
                 "is-callable": "^1.1.3"
-            }
-        },
-        "foreground-child": {
-            "version": "1.5.6",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-            "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
-            "dev": true,
-            "requires": {
-                "cross-spawn": "^4",
-                "signal-exit": "^3.0.0"
-            }
-        },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-            "dev": true
-        },
-        "form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-            "dev": true,
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
             }
         },
         "fs.realpath": {
@@ -640,21 +147,6 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
-        },
-        "get-caller-file": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
         },
         "glob": {
             "version": "7.1.6",
@@ -670,34 +162,6 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
-        "globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "dev": true
-        },
-        "graceful-fs": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
-            "dev": true
-        },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-            "dev": true
-        },
-        "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-            "dev": true,
-            "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
-            }
-        },
         "has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -707,54 +171,10 @@
                 "function-bind": "^1.1.1"
             }
         },
-        "has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
-        },
         "has-symbols": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
             "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-            "dev": true
-        },
-        "hasha": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-            "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
-            "dev": true,
-            "requires": {
-                "is-stream": "^1.0.1"
-            }
-        },
-        "hosted-git-info": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-            "dev": true
-        },
-        "html-escaper": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-            "dev": true
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            }
-        },
-        "imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
         "inflight": {
@@ -779,12 +199,6 @@
             "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
             "dev": true
         },
-        "is-arrayish": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-            "dev": true
-        },
         "is-callable": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
@@ -797,12 +211,6 @@
             "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
             "dev": true
         },
-        "is-fullwidth-code-point": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-            "dev": true
-        },
         "is-regex": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -811,12 +219,6 @@
             "requires": {
                 "has": "^1.0.3"
             }
-        },
-        "is-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
         },
         "is-symbol": {
             "version": "1.0.3",
@@ -827,230 +229,10 @@
                 "has-symbols": "^1.0.1"
             }
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-            "dev": true
-        },
-        "isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
-        },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-            "dev": true
-        },
-        "istanbul-lib-coverage": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-            "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
-            "dev": true
-        },
-        "istanbul-lib-hook": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
-            "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
-            "dev": true,
-            "requires": {
-                "append-transform": "^1.0.0"
-            }
-        },
-        "istanbul-lib-instrument": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-            "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
-            "dev": true,
-            "requires": {
-                "@babel/generator": "^7.4.0",
-                "@babel/parser": "^7.4.3",
-                "@babel/template": "^7.4.0",
-                "@babel/traverse": "^7.4.3",
-                "@babel/types": "^7.4.0",
-                "istanbul-lib-coverage": "^2.0.5",
-                "semver": "^6.0.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                    "dev": true
-                }
-            }
-        },
-        "istanbul-lib-report": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-            "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
-            "dev": true,
-            "requires": {
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "supports-color": "^6.1.0"
-            },
-            "dependencies": {
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "istanbul-lib-source-maps": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-            "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "rimraf": "^2.6.3",
-                "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "istanbul-reports": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
-            "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
-            "dev": true,
-            "requires": {
-                "html-escaper": "^2.0.0"
-            }
-        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
-        },
-        "js-yaml": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            }
-        },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true
-        },
-        "jsesc": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "dev": true
-        },
-        "json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-            "dev": true
-        },
-        "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-            "dev": true
-        },
-        "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-            "dev": true
-        },
-        "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-            }
-        },
-        "lcov-parse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-            "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
-            "dev": true
-        },
-        "load-json-file": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0",
-                "strip-bom": "^3.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
-            }
-        },
-        "locate-path": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-            "dev": true,
-            "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-            }
-        },
-        "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-            "dev": true
-        },
-        "lodash.flattendeep": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-            "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-            "dev": true
-        },
-        "log-driver": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-            "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
             "dev": true
         },
         "loose-envify": {
@@ -1060,58 +242,6 @@
             "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
-            }
-        },
-        "lru-cache": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-            "dev": true,
-            "requires": {
-                "pseudomap": "^1.0.2",
-                "yallist": "^2.1.2"
-            }
-        },
-        "make-dir": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-            "dev": true,
-            "requires": {
-                "pify": "^4.0.1",
-                "semver": "^5.6.0"
-            }
-        },
-        "merge-source-map": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-            "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-            "dev": true,
-            "requires": {
-                "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
-        "mime-db": {
-            "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-            "dev": true
-        },
-        "mime-types": {
-            "version": "2.1.27",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-            "dev": true,
-            "requires": {
-                "mime-db": "1.44.0"
             }
         },
         "minimatch": {
@@ -1127,78 +257,6 @@
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
-        },
-        "mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5"
-            }
-        },
-        "ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
-        },
-        "nested-error-stacks": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-            "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
-            "dev": true
-        },
-        "normalize-package-data": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-            "dev": true,
-            "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
-            }
-        },
-        "nyc": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
-            "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
-            "dev": true,
-            "requires": {
-                "archy": "^1.0.0",
-                "caching-transform": "^3.0.2",
-                "convert-source-map": "^1.6.0",
-                "cp-file": "^6.2.0",
-                "find-cache-dir": "^2.1.0",
-                "find-up": "^3.0.0",
-                "foreground-child": "^1.5.6",
-                "glob": "^7.1.3",
-                "istanbul-lib-coverage": "^2.0.5",
-                "istanbul-lib-hook": "^2.0.7",
-                "istanbul-lib-instrument": "^3.3.0",
-                "istanbul-lib-report": "^2.0.8",
-                "istanbul-lib-source-maps": "^3.0.6",
-                "istanbul-reports": "^2.2.4",
-                "js-yaml": "^3.13.1",
-                "make-dir": "^2.1.0",
-                "merge-source-map": "^1.1.0",
-                "resolve-from": "^4.0.0",
-                "rimraf": "^2.6.3",
-                "signal-exit": "^3.0.2",
-                "spawn-wrap": "^1.4.2",
-                "test-exclude": "^5.2.3",
-                "uuid": "^3.3.2",
-                "yargs": "^13.2.2",
-                "yargs-parser": "^13.0.0"
-            }
-        },
-        "oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
         "object-assign": {
@@ -1250,64 +308,6 @@
                 "wrappy": "1"
             }
         },
-        "os-homedir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-            "dev": true
-        },
-        "p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
-            "requires": {
-                "p-try": "^2.0.0"
-            }
-        },
-        "p-locate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-            "dev": true,
-            "requires": {
-                "p-limit": "^2.0.0"
-            }
-        },
-        "p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
-        },
-        "package-hash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-            "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.15",
-                "hasha": "^3.0.0",
-                "lodash.flattendeep": "^4.4.0",
-                "release-zalgo": "^1.0.0"
-            }
-        },
-        "parse-json": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-            "dev": true,
-            "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
-            }
-        },
-        "path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-            "dev": true
-        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1320,44 +320,6 @@
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
         },
-        "path-type": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-            "dev": true,
-            "requires": {
-                "pify": "^3.0.0"
-            },
-            "dependencies": {
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
-            }
-        },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-            "dev": true
-        },
-        "pify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true
-        },
-        "pkg-dir": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-            "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-            "dev": true,
-            "requires": {
-                "find-up": "^3.0.0"
-            }
-        },
         "prop-types": {
             "version": "15.7.2",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -1369,34 +331,10 @@
                 "react-is": "^16.8.1"
             }
         },
-        "pseudomap": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-            "dev": true
-        },
-        "psl": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-            "dev": true
-        },
-        "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true
-        },
-        "qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-            "dev": true
-        },
         "quip-apps-api": {
-            "version": "1.0.0-alpha.17",
-            "resolved": "https://registry.npmjs.org/quip-apps-api/-/quip-apps-api-1.0.0-alpha.17.tgz",
-            "integrity": "sha512-kTrUs7/fkxACqAbz6cKccyEnPc+j2oGMe34jt5CkoK61Ah3Qq4eANPm+xtmXS08HANSDwaFaLypXtHvW5ep+2Q=="
+            "version": "1.0.0-alpha.20",
+            "resolved": "https://registry.npmjs.org/quip-apps-api/-/quip-apps-api-1.0.0-alpha.20.tgz",
+            "integrity": "sha512-qS6Lqp3+WRMuXfxIdSbYJey+2Wr8qQx8Y+xtSKmLqJ8Jgv5BCoNcW0OsT8gGaqUsAZyNzNXMy8Xsu9N0n56iNQ=="
         },
         "react": {
             "version": "16.13.1",
@@ -1415,27 +353,6 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true
         },
-        "read-pkg": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-            "dev": true,
-            "requires": {
-                "load-json-file": "^4.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
-            }
-        },
-        "read-pkg-up": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-            "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-            "dev": true,
-            "requires": {
-                "find-up": "^3.0.0",
-                "read-pkg": "^3.0.0"
-            }
-        },
         "regexp.prototype.flags": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
@@ -1446,55 +363,6 @@
                 "es-abstract": "^1.17.0-next.1"
             }
         },
-        "release-zalgo": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-            "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-            "dev": true,
-            "requires": {
-                "es6-error": "^4.0.1"
-            }
-        },
-        "request": {
-            "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-            "dev": true,
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            }
-        },
-        "require-directory": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true
-        },
-        "require-main-filename": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-            "dev": true
-        },
         "resolve": {
             "version": "1.17.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -1504,12 +372,6 @@
                 "path-parse": "^1.0.6"
             }
         },
-        "resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true
-        },
         "resumer": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
@@ -1517,131 +379,6 @@
             "dev": true,
             "requires": {
                 "through": "~2.3.4"
-            }
-        },
-        "rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3"
-            }
-        },
-        "safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true
-        },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
-        },
-        "semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "dev": true
-        },
-        "set-blocking": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-            "dev": true
-        },
-        "signal-exit": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-            "dev": true
-        },
-        "source-map": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-            "dev": true
-        },
-        "spawn-wrap": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
-            "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
-            "dev": true,
-            "requires": {
-                "foreground-child": "^1.5.6",
-                "mkdirp": "^0.5.0",
-                "os-homedir": "^1.0.1",
-                "rimraf": "^2.6.2",
-                "signal-exit": "^3.0.2",
-                "which": "^1.3.0"
-            }
-        },
-        "spdx-correct": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-            "dev": true,
-            "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-exceptions": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-            "dev": true
-        },
-        "spdx-expression-parse": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-            "dev": true,
-            "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-            }
-        },
-        "spdx-license-ids": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-            "dev": true
-        },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        },
-        "sshpk": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-            "dev": true,
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
-        },
-        "string-width": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-            "dev": true,
-            "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
             }
         },
         "string.prototype.trim": {
@@ -1675,30 +412,6 @@
                 "es-abstract": "^1.17.5"
             }
         },
-        "strip-ansi": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^4.1.0"
-            }
-        },
-        "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-            "dev": true
-        },
-        "supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "requires": {
-                "has-flag": "^3.0.0"
-            }
-        },
         "tape": {
             "version": "4.13.3",
             "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
@@ -1722,53 +435,10 @@
                 "through": "~2.3.8"
             }
         },
-        "test-exclude": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-            "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.3",
-                "minimatch": "^3.0.4",
-                "read-pkg-up": "^4.0.0",
-                "require-main-filename": "^2.0.0"
-            }
-        },
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
-        },
-        "to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-            "dev": true
-        },
-        "tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-            "dev": true,
-            "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-            }
-        },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
             "dev": true
         },
         "typescript": {
@@ -1777,124 +447,11 @@
             "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
             "dev": true
         },
-        "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-            "dev": true,
-            "requires": {
-                "punycode": "^2.1.0"
-            }
-        },
-        "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "dev": true
-        },
-        "validate-npm-package-license": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-            "dev": true,
-            "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-            }
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "which": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-            "dev": true,
-            "requires": {
-                "isexe": "^2.0.0"
-            }
-        },
-        "which-module": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-            "dev": true
-        },
-        "wrap-ansi": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-            "dev": true,
-            "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-            }
-        },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
             "dev": true
-        },
-        "write-file-atomic": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-            "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
-            }
-        },
-        "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-            "dev": true
-        },
-        "yallist": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-            "dev": true
-        },
-        "yargs": {
-            "version": "13.3.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-            "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-            "dev": true,
-            "requires": {
-                "cliui": "^5.0.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^2.0.1",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^2.0.0",
-                "set-blocking": "^2.0.0",
-                "string-width": "^3.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
-                "yargs-parser": "^13.1.2"
-            }
-        },
-        "yargs-parser": {
-            "version": "13.1.2",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-            "dev": true,
-            "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-            }
         }
     }
 }

--- a/packages/quip-test-utils/package-lock.json
+++ b/packages/quip-test-utils/package-lock.json
@@ -4,22 +4,6 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@types/prop-types": {
-            "version": "15.7.3",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-            "dev": true
-        },
-        "@types/react": {
-            "version": "16.9.41",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz",
-            "integrity": "sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==",
-            "dev": true,
-            "requires": {
-                "@types/prop-types": "*",
-                "csstype": "^2.2.0"
-            }
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -40,12 +24,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
-        },
-        "csstype": {
-            "version": "2.6.11",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-            "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
             "dev": true
         },
         "deep-equal": {

--- a/packages/quip-test-utils/package-lock.json
+++ b/packages/quip-test-utils/package-lock.json
@@ -1,0 +1,1900 @@
+{
+    "name": "quip-test-utils",
+    "version": "1.0.0-alpha.17",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.10.4"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
+            "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.13",
+                "source-map": "^0.5.0"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+            "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+            "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+            "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+            "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+            "dev": true
+        },
+        "@babel/highlight": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+            "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
+            "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
+            "dev": true
+        },
+        "@babel/template": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+            "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
+            "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.10.4",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.13"
+            }
+        },
+        "@babel/types": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
+            "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.13",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@types/prop-types": {
+            "version": "15.7.3",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+            "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+            "dev": true
+        },
+        "@types/react": {
+            "version": "16.9.41",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.41.tgz",
+            "integrity": "sha512-6cFei7F7L4wwuM+IND/Q2cV1koQUvJ8iSV+Gwn0c3kvABZ691g7sp3hfEQHOUBJtccl1gPi+EyNjMIl9nGA0ug==",
+            "dev": true,
+            "requires": {
+                "@types/prop-types": "*",
+                "csstype": "^2.2.0"
+            }
+        },
+        "ajv": {
+            "version": "6.12.3",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+            "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-regex": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "append-transform": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+            "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "^2.0.0"
+            }
+        },
+        "archy": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+            "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "caching-transform": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
+            "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+            "dev": true,
+            "requires": {
+                "hasha": "^3.0.0",
+                "make-dir": "^2.0.0",
+                "package-hash": "^3.0.0",
+                "write-file-atomic": "^2.4.2"
+            }
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "cliui": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+            "dev": true,
+            "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                }
+            }
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "coveralls": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+            "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+            "dev": true,
+            "requires": {
+                "js-yaml": "^3.13.1",
+                "lcov-parse": "^1.0.0",
+                "log-driver": "^1.2.7",
+                "minimist": "^1.2.5",
+                "request": "^2.88.2"
+            }
+        },
+        "cp-file": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
+            "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^2.0.0",
+                "nested-error-stacks": "^2.0.0",
+                "pify": "^4.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "cross-spawn": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+            "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
+            }
+        },
+        "csstype": {
+            "version": "2.6.11",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
+            "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
+            "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "debug": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "dev": true,
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "deep-equal": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+            "dev": true,
+            "requires": {
+                "is-arguments": "^1.0.4",
+                "is-date-object": "^1.0.1",
+                "is-regex": "^1.0.4",
+                "object-is": "^1.0.1",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.2.0"
+            }
+        },
+        "default-require-extensions": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+            "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+            "dev": true,
+            "requires": {
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "dotignore": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
+            "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
+            "dev": true,
+            "requires": {
+                "minimatch": "^3.0.4"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+            "dev": true
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.17.6",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+            "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.0",
+                "is-regex": "^1.1.0",
+                "object-inspect": "^1.7.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.0",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+            },
+            "dependencies": {
+                "is-regex": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+                    "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+                    "dev": true,
+                    "requires": {
+                        "has-symbols": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
+        },
+        "find-cache-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+            "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+            }
+        },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+            "dev": true,
+            "requires": {
+                "locate-path": "^3.0.0"
+            }
+        },
+        "for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
+        },
+        "foreground-child": {
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+            "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "dev": true
+        },
+        "hasha": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+            "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+            "dev": true,
+            "requires": {
+                "is-stream": "^1.0.1"
+            }
+        },
+        "hosted-git-info": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+            "dev": true
+        },
+        "html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "is-arguments": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+            "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+            "dev": true
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-callable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+            "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+            "dev": true
+        },
+        "is-date-object": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-regex": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+            "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+            "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+            "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
+            "dev": true,
+            "requires": {
+                "append-transform": "^1.0.0"
+            }
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+            "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/template": "^7.4.0",
+                "@babel/traverse": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+            "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+            "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "rimraf": "^2.6.3",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+            "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
+            "dev": true,
+            "requires": {
+                "html-escaper": "^2.0.0"
+            }
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "lcov-parse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+            "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+            "dev": true
+        },
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
+            }
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "dev": true
+        },
+        "lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "log-driver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+            "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "lru-cache": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "dev": true,
+            "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+            }
+        },
+        "make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
+            "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            }
+        },
+        "merge-source-map": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+            "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "mime-db": {
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.27",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.44.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
+        },
+        "nested-error-stacks": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+            "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+            "dev": true
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "nyc": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
+            "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "caching-transform": "^3.0.2",
+                "convert-source-map": "^1.6.0",
+                "cp-file": "^6.2.0",
+                "find-cache-dir": "^2.1.0",
+                "find-up": "^3.0.0",
+                "foreground-child": "^1.5.6",
+                "glob": "^7.1.3",
+                "istanbul-lib-coverage": "^2.0.5",
+                "istanbul-lib-hook": "^2.0.7",
+                "istanbul-lib-instrument": "^3.3.0",
+                "istanbul-lib-report": "^2.0.8",
+                "istanbul-lib-source-maps": "^3.0.6",
+                "istanbul-reports": "^2.2.4",
+                "js-yaml": "^3.13.1",
+                "make-dir": "^2.1.0",
+                "merge-source-map": "^1.1.0",
+                "resolve-from": "^4.0.0",
+                "rimraf": "^2.6.3",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^5.2.3",
+                "uuid": "^3.3.2",
+                "yargs": "^13.2.2",
+                "yargs-parser": "^13.0.0"
+            }
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-inspect": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+            "dev": true
+        },
+        "object-is": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+            "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            }
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "dev": true
+        },
+        "package-hash": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+            "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^3.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            }
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "path-type": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                    "dev": true
+                }
+            }
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "pify": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "dev": true
+        },
+        "pkg-dir": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0"
+            }
+        },
+        "prop-types": {
+            "version": "15.7.2",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+            "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.8.1"
+            }
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "psl": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+            "dev": true
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
+        },
+        "quip-apps-api": {
+            "version": "1.0.0-alpha.17",
+            "resolved": "https://registry.npmjs.org/quip-apps-api/-/quip-apps-api-1.0.0-alpha.17.tgz",
+            "integrity": "sha512-kTrUs7/fkxACqAbz6cKccyEnPc+j2oGMe34jt5CkoK61Ah3Qq4eANPm+xtmXS08HANSDwaFaLypXtHvW5ep+2Q=="
+        },
+        "react": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+            "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2"
+            }
+        },
+        "react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "dev": true
+        },
+        "read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+            "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+            }
+        },
+        "regexp.prototype.flags": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+            "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
+            }
+        },
+        "release-zalgo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+            "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+            "dev": true,
+            "requires": {
+                "es6-error": "^4.0.1"
+            }
+        },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+            "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true
+        },
+        "resumer": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+            "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+            "dev": true,
+            "requires": {
+                "through": "~2.3.4"
+            }
+        },
+        "rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "spawn-wrap": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
+            "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
+            "dev": true,
+            "requires": {
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "string-width": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+            "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+            "dev": true,
+            "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+            }
+        },
+        "string.prototype.trim": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
+            "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1",
+                "function-bind": "^1.1.1"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+            "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+            "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            }
+        },
+        "strip-ansi": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^4.1.0"
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "tape": {
+            "version": "4.13.3",
+            "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.3.tgz",
+            "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
+            "dev": true,
+            "requires": {
+                "deep-equal": "~1.1.1",
+                "defined": "~1.0.0",
+                "dotignore": "~0.1.2",
+                "for-each": "~0.3.3",
+                "function-bind": "~1.1.1",
+                "glob": "~7.1.6",
+                "has": "~1.0.3",
+                "inherits": "~2.0.4",
+                "is-regex": "~1.0.5",
+                "minimist": "~1.2.5",
+                "object-inspect": "~1.7.0",
+                "resolve": "~1.17.0",
+                "resumer": "~0.0.0",
+                "string.prototype.trim": "~1.2.1",
+                "through": "~2.3.8"
+            }
+        },
+        "test-exclude": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+            "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^2.0.0"
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
+            "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
+        "typescript": {
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+            "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write-file-atomic": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+            "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "13.3.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+            "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+            "dev": true,
+            "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.2"
+            }
+        },
+        "yargs-parser": {
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
+        }
+    }
+}

--- a/packages/quip-test-utils/package.json
+++ b/packages/quip-test-utils/package.json
@@ -19,7 +19,6 @@
     },
     "homepage": "https://github.com/quip/quip-apps#readme",
     "devDependencies": {
-        "@types/react": "^16.9.41",
         "react": "^16.13.1",
         "tape": "^4.11.0",
         "typescript": "^3.6.3"

--- a/packages/quip-test-utils/package.json
+++ b/packages/quip-test-utils/package.json
@@ -25,6 +25,6 @@
         "typescript": "^3.6.3"
     },
     "dependencies": {
-        "quip-apps-api": "^1.0.0-alpha.17"
+        "quip-apps-api": "^1.0.0-alpha.20"
     }
 }

--- a/packages/quip-test-utils/package.json
+++ b/packages/quip-test-utils/package.json
@@ -1,0 +1,30 @@
+{
+    "name": "quip-test-utils",
+    "version": "1.0.0-alpha.17",
+    "description": "Quip Live Apps Test Utilities",
+    "main": "dist/test-utils.js",
+    "scripts": {
+        "build": "tsc",
+        "test": "npm run build && tape test/**/*.test.js",
+        "prepublishOnly": "npm run build"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/quip/quip-apps.git"
+    },
+    "author": "Quip",
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/quip/quip-apps/issues"
+    },
+    "homepage": "https://github.com/quip/quip-apps#readme",
+    "devDependencies": {
+        "@types/react": "^16.9.41",
+        "react": "^16.13.1",
+        "tape": "^4.11.0",
+        "typescript": "^3.6.3"
+    },
+    "dependencies": {
+        "quip-apps-api": "^1.0.0-alpha.17"
+    }
+}

--- a/packages/quip-test-utils/package.json
+++ b/packages/quip-test-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quip-test-utils",
-    "version": "1.0.0-alpha.17",
+    "version": "1.0.0-alpha.21",
     "description": "Quip Live Apps Test Utilities",
     "main": "dist/test-utils.js",
     "scripts": {

--- a/packages/quip-test-utils/src/apply-snapshot.ts
+++ b/packages/quip-test-utils/src/apply-snapshot.ts
@@ -1,0 +1,66 @@
+// Copyright 2020 Quip
+import quip from "quip-apps-api";
+
+enum PropertyType {
+    PRIMITIVE = 0,
+    RECORD = 1,
+    RECORD_LIST = 2,
+}
+
+interface SnapshotNode {
+    [key: string]: {
+        t: PropertyType;
+        v: any;
+        children?: Array<SnapshotNode>;
+    };
+}
+
+interface Snapshot {
+    data: SnapshotNode;
+}
+
+function applyRecordSnapshot(
+    record: quip.apps.Record,
+    data: SnapshotNode,
+    legacyTypes: quip.RecordPropertyDefinition = {}
+) {
+    const statics = record.constructor as typeof quip.apps.Record;
+    // Don't allow new defaults to exist on old records.
+    // @ts-ignore since we break encapsulation on purpose.
+    record.data_ = {};
+    const properties: quip.RecordPropertyDefinition = {
+        ...statics.getProperties(),
+        ...legacyTypes,
+    };
+    for (const key in data) {
+        const node = data[key];
+        const hasType = !!properties[key];
+        if (hasType && node && node.t === PropertyType.RECORD) {
+            record.clear(key);
+            record.set(key, {});
+            const child = record.get(key);
+            applyRecordSnapshot(child, node.v);
+        } else if (hasType && node && node.t === PropertyType.RECORD_LIST) {
+            record.clear(key);
+            record.set(key, []);
+            const list = record.get(key);
+            const children = node.children;
+            if (children) {
+                children.forEach(childData => {
+                    const child = list.add({});
+                    applyRecordSnapshot(child, childData);
+                });
+            }
+        } else if (!node || node.t !== PropertyType.RECORD_LIST) {
+            record.set(key, node ? node.v : undefined);
+        }
+    }
+}
+
+export default function applySnapshot(
+    record: quip.apps.RootRecord,
+    snapshot: Snapshot
+) {
+    const data = snapshot.data;
+    applyRecordSnapshot(record, data);
+}

--- a/packages/quip-test-utils/src/run-migrations.ts
+++ b/packages/quip-test-utils/src/run-migrations.ts
@@ -1,0 +1,55 @@
+// Copyright 2020 Quip
+import fs from "fs";
+import path from "path";
+import quip from "quip-apps-api";
+
+interface Migration {
+    version_number: number;
+    js_file: string;
+}
+
+interface Manifest {
+    manifest_version: number;
+    version_name: string;
+    version_number: number;
+    migrations: Migration[];
+}
+
+export default async function runMigrations(
+    manifest: Manifest,
+    appVersion: number,
+    record: quip.apps.RootRecord
+) {
+    if (!manifest.migrations) {
+        throw new Error(
+            "runMigrations called with a manifest that does not define any migrations. This is probably not intentional."
+        );
+    }
+    const neededMigrations = manifest.migrations
+        .filter(m => m.version_number && appVersion <= m.version_number)
+        .sort((mA, mB) => {
+            if (mA.version_number === mB.version_number) {
+                return mA.js_file < mB.js_file ? -1 : 1;
+            }
+            return mA.version_number < mB.version_number ? -1 : 1;
+        });
+    console.log("needed:", neededMigrations, manifest.migrations);
+    const migrationJs = await Promise.all(
+        neededMigrations.map(m =>
+            fs.promises.readFile(path.join(process.cwd(), m.js_file), "utf-8")
+        )
+    );
+    const remainingMigrations: Promise<void>[] = [];
+    quip.apps.registerMigration = (migration: quip.MigrationFn) => {
+        const migrate = async () => {
+            record = await migration(record);
+        };
+        remainingMigrations.push(migrate());
+    };
+    migrationJs.forEach(js => {
+        console.log(js);
+        const migration = new Function("quip", js);
+        migration(quip);
+    });
+    return Promise.all(remainingMigrations);
+}

--- a/packages/quip-test-utils/src/run-migrations.ts
+++ b/packages/quip-test-utils/src/run-migrations.ts
@@ -33,7 +33,6 @@ export default async function runMigrations(
             }
             return mA.version_number < mB.version_number ? -1 : 1;
         });
-    console.log("needed:", neededMigrations, manifest.migrations);
     const migrationJs = await Promise.all(
         neededMigrations.map(m =>
             fs.promises.readFile(path.join(process.cwd(), m.js_file), "utf-8")
@@ -47,7 +46,6 @@ export default async function runMigrations(
         remainingMigrations.push(migrate());
     };
     migrationJs.forEach(js => {
-        console.log(js);
         const migration = new Function("quip", js);
         migration(quip);
     });

--- a/packages/quip-test-utils/src/test-utils.ts
+++ b/packages/quip-test-utils/src/test-utils.ts
@@ -1,0 +1,2 @@
+export {default as applySnapshot} from "./apply-snapshot";
+export {default as runMigrations} from "./run-migrations";

--- a/packages/quip-test-utils/test/apply-snapshot.test.js
+++ b/packages/quip-test-utils/test/apply-snapshot.test.js
@@ -1,0 +1,130 @@
+const test = require("tape");
+const quip = require("quip-apps-api");
+const {applySnapshot} = require("../dist/test-utils");
+
+test("Test Utils: applySnapshot", t => {
+    t.plan(9);
+
+    const record = new Root();
+    applySnapshot(record, snapshot);
+
+    t.equal(
+        record.get("rootName"),
+        snapshot.data.rootName.v,
+        "root name is copied over"
+    );
+    const child = record.get("child");
+
+    t.ok(child, "child is created");
+    t.ok(child instanceof ChildRecord, "child is right type");
+
+    t.equal(
+        child.get("aString"),
+        snapshot.data.child.v.aString.v,
+        "child string is copied"
+    );
+    t.deepEqual(
+        child.get("anObject"),
+        snapshot.data.child.v.anObject.v,
+        "child object is copied over"
+    );
+
+    const list = child.get("aList");
+    t.ok(list instanceof quip.apps.RecordList, "child list is a RecordList");
+    t.equal(list.count(), 2, "list has the right number of children");
+    const children = list.getRecords();
+    t.equal(
+        children[0].get("name"),
+        snapshot.data.child.v.aList.children[0].name.v,
+        "first child has correct name"
+    );
+    t.equal(
+        children[1].get("name"),
+        snapshot.data.child.v.aList.children[1].name.v,
+        "second child has correct name"
+    );
+});
+
+class ListChild extends quip.apps.Record {
+    static getProperties() {
+        return {
+            name: "string",
+        };
+    }
+}
+
+class ChildRecord extends quip.apps.Record {
+    static getProperties() {
+        return {
+            aString: "string",
+            anObject: "object",
+            aList: quip.apps.RecordList.Type(ListChild),
+        };
+    }
+}
+
+class Root extends quip.apps.RootRecord {
+    static getProperties() {
+        return {
+            rootName: "string",
+            child: ChildRecord,
+        };
+    }
+}
+
+const snapshot = {
+    "element_config_id": "test",
+    "height": 420,
+    "width": 800,
+    "local_id": "test",
+    "data_version": 0,
+    "creation_usec": 1579287440630000,
+    "template_params": "",
+    "is_template": false,
+    "data": {
+        "rootName": {
+            "t": 0,
+            "v": "My Root Name",
+        },
+        "child": {
+            "t": 1,
+            "v": {
+                "aString": {
+                    "t": 0,
+                    "v": "foo",
+                },
+                "anObject": {
+                    "t": 0,
+                    "v": {"key": "val"},
+                },
+                "aList": {
+                    "t": 2,
+                    "v": {
+                        "itemConstructorKey": {
+                            "t": 0,
+                            "v": "listChild",
+                        },
+                        "itemRecordType": {
+                            "t": 0,
+                            "v": 0,
+                        },
+                    },
+                    "children": [
+                        {
+                            "name": {
+                                "t": 0,
+                                "v": "thing one",
+                            },
+                        },
+                        {
+                            "name": {
+                                "t": 0,
+                                "v": "thing two",
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+    },
+};

--- a/packages/quip-test-utils/test/fixtures/example-migration.js
+++ b/packages/quip-test-utils/test/fixtures/example-migration.js
@@ -1,0 +1,10 @@
+/**
+ * deprecates the name "jacob", migrates it to the name "bromst"
+ */
+quip.apps.registerMigration(rootRecord => {
+    const name = rootRecord.get("name");
+    if (name === "jacob") {
+        rootRecord.set("name", "bromst");
+    }
+    return rootRecord;
+});

--- a/packages/quip-test-utils/test/fixtures/migrations-manifest.json
+++ b/packages/quip-test-utils/test/fixtures/migrations-manifest.json
@@ -1,0 +1,14 @@
+{
+    "id": "example-id",
+    "manifest_version": 1,
+    "name": "Test",
+    "description": "test",
+    "version_name": "1.0.0",
+    "version_number": 50,
+    "migrations": [
+        {
+            "version_number": 42,
+            "js_file": "test/fixtures/example-migration.js"
+        }
+    ]
+}

--- a/packages/quip-test-utils/test/run-migrations.test.js
+++ b/packages/quip-test-utils/test/run-migrations.test.js
@@ -1,0 +1,25 @@
+const test = require("tape");
+const quip = require("quip-apps-api");
+const {runMigrations} = require("../dist/test-utils");
+const manifest = require("./fixtures/migrations-manifest.json");
+
+test("v42 deprecates the name 'jacob'", async t => {
+    t.plan(2);
+    const root = new Root();
+    t.equal(root.get("name"), "jacob", "pre-migration name is jacob");
+    await runMigrations(manifest, 42, root);
+    t.equal(root.get("name"), "bromst", "post-migration name is bromst");
+});
+
+class Root extends quip.apps.RootRecord {}
+Root.ID = "root";
+Root.getProperties = function() {
+    return {
+        name: "string",
+    };
+};
+Root.getDefaultProperties = function() {
+    return {
+        name: "jacob",
+    };
+};

--- a/packages/quip-test-utils/tsconfig.json
+++ b/packages/quip-test-utils/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "module": "commonjs",
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "strict": true,
+        "esModuleInterop": true
+    },
+    "include": ["src/**/*"]
+}


### PR DESCRIPTION
Moves applySnapshot over to a new package, `quip-test-utils`, which also now has a `runMigrations` harness for smoke testing your local migrations without having to manually test against a running quip instance.

@gaspar09 @sieut FYI, I'll be migrating some internal stuff over with this.