### PR TITLE
Add templates dir to quip-cli package

### DIFF
--- a/packages/create-quip-app/package-lock.json
+++ b/packages/create-quip-app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-quip-app",
-  "version": "1.0.0-alpha.31",
+  "version": "1.0.0-alpha.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -54,9 +54,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g=="
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
         }
       }
     },
@@ -591,6 +591,15 @@
         "mimic-fn": "^2.1.0"
       }
     },
+    "open": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.1.0.tgz",
+      "integrity": "sha512-lLPI5KgOwEYCDKXf4np7y1PBEkj7HYIyP2DY8mVDRnx0VIIu6bNrRB0R66TuO7Mack6EnTNLm4uvcl1UoklTpA==",
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -612,9 +621,9 @@
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
     },
     "quip-cli": {
-      "version": "1.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/quip-cli/-/quip-cli-1.0.0-alpha.23.tgz",
-      "integrity": "sha512-mF95lpvh5cYez7rMHnCTx0gf8WA47CYv0iA9txSojVCuJTluTgFS5jUtcg5rAd3gWBqYdNSf6lz0xRfD1k/iRg==",
+      "version": "1.0.0-alpha.35",
+      "resolved": "https://registry.npmjs.org/quip-cli/-/quip-cli-1.0.0-alpha.35.tgz",
+      "integrity": "sha512-BsB53jjAgclqgpEKo0lBNTrvFNtrOfUvGImImZNyl0CBu2XXLdWqWO0p3LtJMWxlJYzX0Zrw9nVoGdC8tO00tA==",
       "requires": {
         "@oclif/command": "^1.6.1",
         "@oclif/config": "^1.15.1",
@@ -622,6 +631,7 @@
         "inquirer": "^7.2.0",
         "mkdirp": "^1.0.4",
         "ncp": "^2.0.0",
+        "open": "^7.0.4",
         "prettier": "^2.0.5",
         "tslib": "^1.13.0"
       }

--- a/packages/create-quip-app/package.json
+++ b/packages/create-quip-app/package.json
@@ -18,6 +18,6 @@
   },
   "gitHead": "1633a60816f6da91d4b022751e9f3bfd45ae18c1",
   "dependencies": {
-    "quip-cli": "latest"
+    "quip-cli": "next"
   }
 }

--- a/packages/quip-cli/package.json
+++ b/packages/quip-cli/package.json
@@ -44,7 +44,8 @@
         "/bin",
         "/lib",
         "/npm-shrinkwrap.json",
-        "/oclif.manifest.json"
+        "/oclif.manifest.json",
+        "templates"
     ],
     "homepage": "https://github.com/quip/quip-apps#readme",
     "keywords": [


### PR DESCRIPTION
create-quip-app depends on quip-cli@next

Fixes quip-cli init script was missing the templates on the npm package