### PR TITLE
Gaspar09/allow usr node modules on init filter

### DIFF
--- a/packages/quip-cli/src/commands/init.ts
+++ b/packages/quip-cli/src/commands/init.ts
@@ -162,7 +162,7 @@ export default class Init extends Command {
         );
         const options = {
             dereference: true,
-            // For use during local developement. Do not copy ,git and boilerplate node_modules
+            // For use during local developement. Do not copy .git and boilerplate node_modules
             filter: (fileName: string) =>
                 !fileName.match(/(?:\.git\/|templates\/[\w_]+\/node_modules)/),
         };

--- a/packages/quip-cli/src/commands/init.ts
+++ b/packages/quip-cli/src/commands/init.ts
@@ -162,9 +162,9 @@ export default class Init extends Command {
         );
         const options = {
             dereference: true,
+            // For use during local developement. Do not copy ,git and boilerplate node_modules
             filter: (fileName: string) =>
-                fileName.indexOf("node_modules") === -1 &&
-                fileName.indexOf(".git/") === -1,
+                !fileName.match(/(?:\.git\/|templates\/[\w_]+\/node_modules)/),
         };
         const dest = path.join(process.cwd(), name);
         if (dryRun) {


### PR DESCRIPTION
Fixes copying templates from /usr/local/lib/node_modules
which was previously filtered away by ncp copy util