### PR TITLE
init fixes

### DIFF
--- a/packages/quip-cli/README.md
+++ b/packages/quip-cli/README.md
@@ -3,52 +3,47 @@
 This package contains the Quip command line interface, which is used for interacting with the Quip Live Apps platform.
 
 <!-- toc -->
-
--   [Quip CLI](#quip-cli)
--   [Usage](#usage)
--   [Commands](#commands)
+* [Quip CLI](#quip-cli)
+* [Usage](#usage)
+* [Commands](#commands)
 <!-- tocstop -->
 
 # Usage
 
 <!-- usage -->
-
 ```sh-session
 $ npm install -g quip-cli
 $ qla COMMAND
 running command...
 $ qla (-v|--version|version)
-quip-cli/1.0.0-alpha.40 linux-x64 node-v12.18.3
+quip-cli/1.0.0-alpha.44 darwin-x64 node-v10.15.0
 $ qla --help [COMMAND]
 USAGE
   $ qla COMMAND
 ...
 ```
-
 <!-- usagestop -->
 
 # Commands
 
 <!-- commands -->
-
--   [`qla apps`](#qla-apps)
--   [`qla bump [INCREMENT]`](#qla-bump-increment)
--   [`qla help [COMMAND]`](#qla-help-command)
--   [`qla init`](#qla-init)
--   [`qla login`](#qla-login)
--   [`qla migration [NAME]`](#qla-migration-name)
--   [`qla publish`](#qla-publish)
+* [`qla apps`](#qla-apps)
+* [`qla bump [INCREMENT]`](#qla-bump-increment)
+* [`qla help [COMMAND]`](#qla-help-command)
+* [`qla init`](#qla-init)
+* [`qla login`](#qla-login)
+* [`qla migration [NAME]`](#qla-migration-name)
+* [`qla publish`](#qla-publish)
 
 ## `qla apps`
 
-Browse, inspect, create, and manipulate your Apps
+Browse, inspect, and manipulate your Apps
 
 ```
 USAGE
   $ qla apps
 
 OPTIONS
-  -c, --create           create a new live app
   -h, --help             show CLI help
   -i, --id=id            show the details of an app ID
   -j, --json             output responses in JSON
@@ -56,7 +51,7 @@ OPTIONS
   -v, --version=version  which version to show the details for. Only useful with --id
 ```
 
-_See code: [src/commands/apps.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.24/src/commands/apps.ts)_
+_See code: [src/commands/apps.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/apps.ts)_
 
 ## `qla bump [INCREMENT]`
 
@@ -73,7 +68,7 @@ OPTIONS
   -h, --help  show CLI help
 ```
 
-_See code: [src/commands/bump.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.24/src/commands/bump.ts)_
+_See code: [src/commands/bump.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/bump.ts)_
 
 ## `qla help [COMMAND]`
 
@@ -101,10 +96,16 @@ USAGE
   $ qla init
 
 OPTIONS
-  -h, --help  show CLI help
+  -d, --dir=dir    specify directory to create app in (defaults to the name provided)
+  -h, --help       show CLI help
+  -i, --id=id      set the ID of the application
+  -j, --json       output responses in JSON (must provide --name and --id)
+  -n, --name=name  set the name of the application
+  -s, --site=site  [default: quip.com] use a specific quip site rather than the standard quip.com login
+  --no-create      only create a local app (don't create an app in the dev console or assign an ID)
 ```
 
-_See code: [src/commands/init.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.40/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/init.ts)_
 
 ## `qla login`
 
@@ -120,7 +121,7 @@ OPTIONS
   -s, --site=site  [default: quip.com] use a specific quip site rather than the standard quip.com login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.40/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/login.ts)_
 
 ## `qla migration [NAME]`
 
@@ -134,15 +135,15 @@ ARGUMENTS
   NAME  A short description to generate the filename with
 
 OPTIONS
-  -f, --folder=folder      [default: migrations] The folder where your migrations are stored
-  -h, --help               show CLI help
-  -m, --manifest=manifest  A manifest.json file to add the migration to. By default, we'll use the first one we find.
+  -d, --dry-run          Print what this would do, but don't create any files.
+  -f, --folder=folder    [default: migrations] The folder where your migrations are stored
+  -h, --help             show CLI help
 
-  -v, --version=version    The version to generate this migration for. By default, it will use the current
-                           version_number in the manifest
+  -v, --version=version  The version to generate this migration for. By default, it will use the current version_number
+                         in the manifest
 ```
 
-_See code: [src/commands/migration.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.24/src/commands/migration.ts)_
+_See code: [src/commands/migration.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/migration.ts)_
 
 ## `qla publish`
 
@@ -153,13 +154,13 @@ USAGE
   $ qla publish
 
 OPTIONS
-  -d, --dist=dist  [default: ./dist] dist folder to upload
-  -h, --help       show CLI help
-  -s, --site=site  [default: quip.com] use a specific quip site rather than the standard quip.com login
+  -h, --help           show CLI help
+  -i, --ignore=ignore  [default: node_modules] blob to ignore. Defaults to 'node_modules'
+  -j, --json           output responses in JSON
+  -s, --site=site      [default: quip.com] use a specific quip site rather than the standard quip.com login
 ```
 
-_See code: [src/commands/publish.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.24/src/commands/publish.ts)_
-
+_See code: [src/commands/publish.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/publish.ts)_
 <!-- commandsstop -->
 
 ## Running locally

--- a/packages/quip-cli/bin/run
+++ b/packages/quip-cli/bin/run
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
-require('@oclif/command').run()
-.then(require('@oclif/command/flush'))
-.catch(require('@oclif/errors/handle'))
+require("@oclif/command")
+    .run()
+    .catch(require("@oclif/errors/handle"))
+    .then(require("@oclif/command/flush"));

--- a/packages/quip-cli/src/commands/init.ts
+++ b/packages/quip-cli/src/commands/init.ts
@@ -31,7 +31,8 @@ const defaultName = (dir?: string) => {
         .replace(/(:?^|\s)(\w)/g, (c) => c.toUpperCase());
 };
 
-const packageName = (name: string) => name.toLowerCase().replace(/\s+/g, "-");
+const packageName = (name: string) =>
+    name.toLowerCase().trim().replace(/\s+/g, "-");
 
 const getAppDir = (name: string, dir?: string) => {
     if (dir && dir.length) {
@@ -87,6 +88,7 @@ export default class Init extends Command {
             char: "j",
             description:
                 "output responses in JSON (must provide --name and --id)",
+            dependsOn: ["name", "id"],
         }),
         name: flags.string({
             char: "n",
@@ -275,12 +277,6 @@ export default class Init extends Command {
         const dryRun = flags["dry-run"];
         const fetch = await cliAPI(flags.config, flags.site);
         const shouldCreate = !flags["no-create"];
-        if (flags.json && (!flags.name || !flags.id)) {
-            println(
-                chalk`{red You must provide --name and --id when initializing with --json}`
-            );
-            process.exit(1);
-        }
         if (shouldCreate) {
             const ok = await successOnly(fetch("ok"), false);
             if (!ok) {

--- a/packages/quip-cli/src/commands/init.ts
+++ b/packages/quip-cli/src/commands/init.ts
@@ -31,6 +31,8 @@ const defaultName = (dir?: string) => {
         .replace(/(:?^|\s)(\w)/g, (c) => c.toUpperCase());
 };
 
+const packageName = (name: string) => name.toLowerCase().replace(/\s+/g, "-");
+
 const getAppDir = (name: string, dir?: string) => {
     if (dir && dir.length) {
         if (dir.startsWith("/")) {
@@ -42,13 +44,17 @@ const getAppDir = (name: string, dir?: string) => {
 };
 
 const defaultPackageOptions = (name: string) => ({
-    name: name.toLowerCase().replace(/\s+/g, "-"),
+    name: packageName(name),
     description: "A Quip Live App",
     typescript: true,
 });
 
-const defaultManifestOptions = (dir?: string) => ({
+const defaultManifestOptions = (
+    dir?: string,
+    opts?: {name?: string; id?: string}
+) => ({
     name: defaultName(dir),
+    ...(opts || {}),
 });
 
 export default class Init extends Command {
@@ -79,11 +85,16 @@ export default class Init extends Command {
         }),
         json: flags.boolean({
             char: "j",
-            description: "output responses in JSON (must provide --name)",
+            description:
+                "output responses in JSON (must provide --name and --id)",
         }),
         name: flags.string({
             char: "n",
             description: "set the name of the application",
+        }),
+        id: flags.string({
+            char: "i",
+            description: "set the ID of the application",
         }),
         config: flags.string({
             hidden: true,
@@ -92,11 +103,14 @@ export default class Init extends Command {
         }),
     };
 
-    private promptInitialAppConfig_ = async (specifiedDir?: string) => {
+    private promptInitialAppConfig_ = async (
+        specifiedDir?: string,
+        defaults?: {name?: string; id?: string}
+    ) => {
         println("Creating a new Quip Live App");
         const validateNumber: (input: any) => true | string = (val) =>
             !isNaN(parseInt(val, 10)) || "Please enter a number";
-        const defaultManifest = defaultManifestOptions(specifiedDir);
+        const defaultManifest = defaultManifestOptions(specifiedDir, defaults);
         const manifestOptions: Manifest = await inquirer.prompt([
             {
                 type: "input",
@@ -202,7 +216,9 @@ export default class Init extends Command {
     ) => {
         const {typescript, bundler} = packageOptions;
         // get lib path
-        const templateName = `${typescript ? "ts" : "js"}_${bundler}`;
+        const templateName = `${typescript ? "ts" : "js"}_${
+            bundler || "webpack"
+        }`;
         const templatePath = path.join(
             __dirname,
             "../../templates",
@@ -259,9 +275,9 @@ export default class Init extends Command {
         const dryRun = flags["dry-run"];
         const fetch = await cliAPI(flags.config, flags.site);
         const shouldCreate = !flags["no-create"];
-        if (flags.json && !flags.name) {
+        if (flags.json && (!flags.name || !flags.id)) {
             println(
-                chalk`{red You must provide --name when initializing with --json}`
+                chalk`{red You must provide --name and --id when initializing with --json}`
             );
             process.exit(1);
         }
@@ -281,16 +297,23 @@ export default class Init extends Command {
                   manifestOptions: Partial<Manifest>;
               }
             | undefined;
-        if (flags.name && flags.json) {
-            const manifestOptions = defaultManifestOptions(flags.dir);
+        if (flags.name && flags.json && flags.id) {
+            const manifestOptions = defaultManifestOptions(flags.dir, {
+                name: flags.name,
+                id: flags.id,
+            });
+            const packageOptions = defaultPackageOptions(manifestOptions.name);
             config = {
-                appDir: getAppDir(flags.name, flags.dir),
+                appDir: getAppDir(packageOptions.name, flags.dir),
                 manifestOptions,
-                packageOptions: defaultPackageOptions(manifestOptions.name),
+                packageOptions,
             };
         } else {
             // initial app options from user
-            config = await this.promptInitialAppConfig_(flags.dir);
+            config = await this.promptInitialAppConfig_(flags.dir, {
+                name: flags.name,
+                id: flags.id,
+            });
         }
         const {packageOptions, manifestOptions, appDir} = config;
         await this.copyTemplate_(packageOptions, appDir, dryRun);
@@ -351,6 +374,8 @@ export default class Init extends Command {
                     process.exit(1);
                 }
             }
+        } else if (flags.json && success) {
+            print(JSON.stringify(manifest));
         }
         if (!flags.json && success) {
             println(


### PR DESCRIPTION
Make --id required when programatically initializing apps, make --name work as expected both with and without --json

Fixes https://github.com/quip/quip-apps/issues/112
Fixes https://github.com/quip/quip-apps/issues/113