### PR TITLE
Soft deprecate create-quip-app script

### DIFF
--- a/packages/create-quip-app/README.md
+++ b/packages/create-quip-app/README.md
@@ -1,5 +1,9 @@
+# Deprecation Notice
+
+`create-quip-app` is deprecated, use `quip-cli init` instead. See [documentation](https://github.com/quip/quip-apps/tree/master/packages/quip-cli#qla-init) for more details on `quip-cli`.
+
 ## Version Notes
 
 ### 0.0.15
-Updates `quip-apps-webpack-config` to v0.0.14, which requires removing `-p` from the `package.json scripts.build` config. Otherwise, `npm run build` results in `ERROR in app.js from UglifyJs` `TypeError: Cannot read property 'sections' of null`.
 
+Updates `quip-apps-webpack-config` to v0.0.14, which requires removing `-p` from the `package.json scripts.build` config. Otherwise, `npm run build` results in `ERROR in app.js from UglifyJs` `TypeError: Cannot read property 'sections' of null`.

--- a/packages/create-quip-app/bin/create-quip-app.py
+++ b/packages/create-quip-app/bin/create-quip-app.py
@@ -49,7 +49,7 @@ def init_app():
     quip_cli_path = os.path.join(
         script_path, "..", "node_modules", "quip-cli", "bin", "run")
     subprocess.check_call(
-        "%s init" % quip_cli_path,
+        "%s init --no-create --json --name \"Live App\" --id \"LIVE_APP_ID\"" % quip_cli_path,
         shell=True,
     )
 


### PR DESCRIPTION
Depends on #131, because it uses the --id param.

Fixes #129 by aliasing a different, modern API (--json, --no-create)

Adds a README deprecation. Ideally we'll eventually do something like https://github.com/quip/quip-apps/pull/132 but we still need the python script to support a `pack` based flow for a while.