### PR TITLE
Add support for passing gitsha when available

### DIFF
--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -137,13 +137,8 @@ export default class Login extends Command {
             this.error(
                 new Error(
                     `Failed to acquire access token: ${
-                        tokenResponse.error ||
-                        `no code returned, got ${JSON.stringify(
-                            tokenResponse,
-                            null,
-                            2
-                        )}`
-                    }`
+                        tokenResponse.error
+                    } - response: ${JSON.stringify(tokenResponse, null, 2)}`
                 )
             );
         }


### PR DESCRIPTION
- adds new runCmdPromise for use cases where we want to allow failure
- print better error messages when the server returns an unhelpful error
- attempt to get HEAD sha whenever running publish and add it to the form if it doesn't fail