### PR TITLE
Address some issues with the legacy create-quip-app migration

### DIFF
--- a/packages/create-quip-app/package-lock.json
+++ b/packages/create-quip-app/package-lock.json
@@ -59,9 +59,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.2.tgz",
-          "integrity": "sha512-wAH28hcEKwna96/UacuWaVspVLkg4x1aDM9JlzqaQTOFczCktkVAb5fmXChgandR1EraDPs2w8P+ozM+oafwxg=="
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
         }
       }
     },
@@ -713,9 +713,9 @@
       "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg=="
     },
     "quip-cli": {
-      "version": "0.1.2-alpha.1",
-      "resolved": "https://registry.npmjs.org/quip-cli/-/quip-cli-0.1.2-alpha.1.tgz",
-      "integrity": "sha512-gRLPw4fGg4qH/jkkM+I14bIwoehYhl+GRX3jOSkagLGi4WACxW7f3cqX3vF68/YnPOM+1WLXQa/vNwf4hrKEYg==",
+      "version": "0.1.2-alpha.4",
+      "resolved": "https://registry.npmjs.org/quip-cli/-/quip-cli-0.1.2-alpha.4.tgz",
+      "integrity": "sha512-Ew9cK1sB7GWL/P3tKCX8mPate4/NjFhYWPh/oSDOBCBIyoRvioozhNTeOwwmsGYeBAgfOBqP3jLe00zhC6Is9A==",
       "requires": {
         "@oclif/command": "^1.6.1",
         "@oclif/config": "^1.15.1",
@@ -842,9 +842,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
-      "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "type-fest": {
       "version": "0.11.0",


### PR DESCRIPTION
Some usability issues and doc gaps were brought up in https://salesforce.stackexchange.com/questions/323509/quip-cannot-create-own-app, this addresses them:

- allows passing an app name as the first arg to create-quip-app
- automatically runs npm install after initializing like it used to
- add "&& create-quip-app pack ." to the app's build script and install create-quip-app as a dev dependency so that app.ele files will be generated