### PR TITLE
Enhancements to `qla bump`

### DIFF
--- a/packages/quip-cli/README.md
+++ b/packages/quip-cli/README.md
@@ -16,7 +16,7 @@ $ npm install -g quip-cli
 $ qla COMMAND
 running command...
 $ qla (-v|--version|version)
-quip-cli/1.0.0-alpha.44 darwin-x64 node-v10.15.0
+quip-cli/0.1.2-alpha.9 darwin-x64 node-v10.15.0
 $ qla --help [COMMAND]
 USAGE
   $ qla COMMAND
@@ -51,24 +51,28 @@ OPTIONS
   -v, --version=version  which version to show the details for. Only useful with --id
 ```
 
-_See code: [src/commands/apps.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/apps.ts)_
+_See code: [src/commands/apps.ts](https://github.com/quip/quip-apps/blob/v0.1.2-alpha.9/src/commands/apps.ts)_
 
 ## `qla bump [INCREMENT]`
 
-Bump the application version
+Bump the application version (and create a version commit/tag)
 
 ```
 USAGE
   $ qla bump [INCREMENT]
 
 ARGUMENTS
-  INCREMENT  which number to bump - can be one of 'major', 'minor', or 'patch' - defaults to 'patch'
+  INCREMENT  which number to bump - can be one of 'prerelease', 'major', 'minor', or 'patch' - defaults to 'patch'
 
 OPTIONS
-  -h, --help  show CLI help
+  -h, --help                             show CLI help
+  -m, --message=message                  Specify a commit message to use as the version commit message
+
+  -p, --prerelease-name=prerelease-name  When specifying prerelease, use this as the prefix, e.g. -p alpha will produce
+                                         v0.x.x-alpha.x
 ```
 
-_See code: [src/commands/bump.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/bump.ts)_
+_See code: [src/commands/bump.ts](https://github.com/quip/quip-apps/blob/v0.1.2-alpha.9/src/commands/bump.ts)_
 
 ## `qla help [COMMAND]`
 
@@ -105,7 +109,7 @@ OPTIONS
   --no-create      only create a local app (don't create an app in the dev console or assign an ID)
 ```
 
-_See code: [src/commands/init.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/quip/quip-apps/blob/v0.1.2-alpha.9/src/commands/init.ts)_
 
 ## `qla login`
 
@@ -121,7 +125,7 @@ OPTIONS
   -s, --site=site  [default: quip.com] use a specific quip site rather than the standard quip.com login
 ```
 
-_See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v0.1.2-alpha.9/src/commands/login.ts)_
 
 ## `qla migration [NAME]`
 
@@ -143,7 +147,7 @@ OPTIONS
                          in the manifest
 ```
 
-_See code: [src/commands/migration.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/migration.ts)_
+_See code: [src/commands/migration.ts](https://github.com/quip/quip-apps/blob/v0.1.2-alpha.9/src/commands/migration.ts)_
 
 ## `qla publish`
 
@@ -160,7 +164,7 @@ OPTIONS
   -s, --site=site      [default: quip.com] use a specific quip site rather than the standard quip.com login
 ```
 
-_See code: [src/commands/publish.ts](https://github.com/quip/quip-apps/blob/v1.0.0-alpha.44/src/commands/publish.ts)_
+_See code: [src/commands/publish.ts](https://github.com/quip/quip-apps/blob/v0.1.2-alpha.9/src/commands/publish.ts)_
 <!-- commandsstop -->
 
 ## Running locally

--- a/packages/quip-cli/package-lock.json
+++ b/packages/quip-cli/package-lock.json
@@ -76,6 +76,12 @@
             }
           }
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1036,6 +1042,13 @@
         "@oclif/plugin-help": "^3",
         "debug": "^4.1.1",
         "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "@oclif/config": {
@@ -1542,6 +1555,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
       "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
       "dev": true
     },
     "@types/sinon": {
@@ -2364,6 +2383,12 @@
           "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
           "dev": true
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -2494,6 +2519,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "cssom": {
@@ -5844,6 +5877,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -6779,9 +6820,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/packages/quip-cli/package.json
+++ b/packages/quip-cli/package.json
@@ -22,6 +22,7 @@
         "open": "^7.0.4",
         "pkce-challenge": "^2.1.0",
         "prettier": "^2.0.5",
+        "semver": "^7.3.2",
         "ssl-root-cas": "^1.3.1",
         "tslib": "^1.13.0"
     },
@@ -37,6 +38,7 @@
         "@types/node-fetch": "^2.5.7",
         "@types/open": "^6.2.1",
         "@types/prettier": "^2.0.2",
+        "@types/semver": "^7.3.4",
         "chai": "^4.2.0",
         "jest": "^26.1.0",
         "mockdate": "^3.0.2",

--- a/packages/quip-cli/src/commands/init.ts
+++ b/packages/quip-cli/src/commands/init.ts
@@ -348,7 +348,7 @@ export default class Init extends Command {
             await runCmd(appDir, "npm", "install");
             // bump the version since we already have a verison 1 in the console
             println(chalk`{green bumping version...}`);
-            await bump(appDir, "patch", flags.json);
+            await bump(appDir, "patch", {silent: flags.json});
             // npm run build
             println(chalk`{green building app...}`);
             await runCmd(appDir, "npm", "run", "build");


### PR DESCRIPTION
- accept 'prerelease' the same way npm version does
- refuse to run when git worktree is dirty
- include manifest.json in git commit/tag
- allow commit message customization