### PR TITLE
Change devServer's contentBase

### DIFF
--- a/packages/webpack-config/webpack.config.js
+++ b/packages/webpack-config/webpack.config.js
@@ -139,7 +139,7 @@ module.exports = {
         quiptext: "quiptext",
     },
     devServer: {
-        contentBase: path.resolve(cwd, "app/dist"),
+        contentBase: path.resolve(cwd, "app"),
         // host: "docker.qa",
         port: 8888,
         inline: false,


### PR DESCRIPTION
Make DevServer content base to be app instead of app/dist so that we can expose manifest.json when using local resources.