### PR TITLE
Clear focus before focusing again just in case the record was focused before

### DIFF
--- a/packages/handleRichTextBoxKeyEventNavigation/handleRichTextBoxKeyEventNavigation.js
+++ b/packages/handleRichTextBoxKeyEventNavigation/handleRichTextBoxKeyEventNavigation.js
@@ -26,6 +26,8 @@ export default function(e, record) {
         if (next.getRichTextRecord) {
             next = next.getRichTextRecord();
         }
+        // Clear the focus just in case it was focused before.
+        next.clearFocus();
         next.focus();
         return true;
     }

--- a/packages/handleRichTextBoxKeyEventNavigation/package.json
+++ b/packages/handleRichTextBoxKeyEventNavigation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quip-apps-handle-richtextbox-key-event-navigation",
-    "version": "0.1.2-alpha.14",
+    "version": "0.2.0",
     "description": "Quip Apps RichTextBox Key Event Navigation",
     "license": "Apache-2.0",
     "repository": "quip/quip-apps",


### PR DESCRIPTION
This is the reason why the live apps (Kankan, poll, process bar that are using this package) 1) couldn't cycle focus within the app and 2) could only tab through the live app once and 3) couldn't shift-tab to go back to the previous record.