### PR TITLE
Create slds-package

### DIFF
--- a/packages/slds-resolver/README.md
+++ b/packages/slds-resolver/README.md
@@ -1,0 +1,6 @@
+# `slds-resolver`
+
+This package is a simple resolver plugin for webpack that will help webpack find assets in the `node_modules/@salesforce-ux/design-system/assets` folder.
+
+Without this module, many assets are pointed to using `url(/assets/...)`, which isn't compatible with workflows where webpack is expected to generate all the necessary assets for a bundle (like Live Apps). Using this resolver will just make these files available to webpack, where you can use `file-loader` or similar to actually package the assets.
+

--- a/packages/slds-resolver/package.json
+++ b/packages/slds-resolver/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "slds-resolver",
+  "version": "0.1.2-alpha.15",
+  "description": "A Webpack Resolver plugin for handling SLDS assets",
+  "author": "Jesse Ditson <jditson@quip.com>",
+  "homepage": "https://github.com/quip/quip-apps#readme",
+  "license": "Apache-2.0",
+  "main": "slds-resolver.js",
+  "files": [
+    "slds-resolver.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/quip/quip-apps.git"
+  },
+  "bugs": {
+    "url": "https://github.com/quip/quip-apps/issues"
+  }
+}

--- a/packages/slds-resolver/slds-resolver.js
+++ b/packages/slds-resolver/slds-resolver.js
@@ -1,0 +1,38 @@
+const path = require("path");
+
+class SLDSResolver {
+    apply(resolver) {
+        const target = resolver.ensureHook("existingFile");
+        resolver
+            .getHook("file")
+            .tapAsync("SLDSPlugin", (request, resolveContext, callback) => {
+                if (
+                    /@salesforce-ux\/design-system/.test(
+                        request.descriptionFileRoot
+                    ) &&
+                    /^\/assets/.test(request.path)
+                ) {
+                    const aliased = Object.assign({}, request, {
+                        path: path.join(
+                            request.descriptionFileRoot,
+                            request.path
+                        ),
+                        relativePath: "." + request.path,
+                    });
+                    resolver.doResolve(
+                        target,
+                        aliased,
+                        `SLDS Asset: ${request.path}: ${path.join(
+                            request.descriptionFileRoot,
+                            request.path
+                        )}`,
+                        resolveContext,
+                        callback
+                    );
+                } else {
+                    callback();
+                }
+            });
+    }
+}
+module.exports = SLDSResolver;


### PR DESCRIPTION
I encountered some issues when attempting to build an app using design-system-react in the "recommended" configuration. This resolver plugin just exposes assets that are pointed to via absolute /assets/ urls to webpack, allowing it to bundle and rewrite the assets.