### PR TITLE
Make cli-initialized apps start at build 1

### DIFF
--- a/packages/quip-cli/src/commands/init.ts
+++ b/packages/quip-cli/src/commands/init.ts
@@ -351,9 +351,9 @@ export default class Init extends Command {
             // npm install
             println(chalk`{green installing dependencies...}`);
             await runCmd(appDir, "npm", "install");
-            // bump the version since we already have a verison 1 in the console
+            // bump the version since we already have a version 0 in the console
             println(chalk`{green bumping version...}`);
-            await bump(appDir, "patch", { silent: flags.json });
+            await bump(appDir, "minor", { silent: flags.json });
             // npm run build
             println(chalk`{green building app...}`);
             await runCmd(appDir, "npm", "run", "build");

--- a/packages/quip-cli/templates/js_webpack/package.json
+++ b/packages/quip-cli/templates/js_webpack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quip-app-boilerplate",
-    "version": "0.1.0",
+    "version": "0.0.0",
     "description": "Quip Live App Boilerplate",
     "license": "UNLICENSED",
     "scripts": {
@@ -31,7 +31,7 @@
     },
     "peerDependencies": {},
     "dependencies": {
-        "quip-apps-api": "^1.0.0-alpha.16",
-        "quiptext": "^1.0.0-alpha.16"
+        "quip-apps-api": "next",
+        "quiptext": "next"
     }
 }

--- a/packages/quip-cli/templates/ts_webpack/package.json
+++ b/packages/quip-cli/templates/ts_webpack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "quip-app-boilerplate",
-    "version": "0.1.0",
+    "version": "0.0.0",
     "description": "Quip Live App Boilerplate",
     "license": "UNLICENSED",
     "scripts": {
@@ -38,7 +38,7 @@
     },
     "peerDependencies": {},
     "dependencies": {
-        "quip-apps-api": "^1.0.0-alpha.16",
-        "quiptext": "^1.0.0-alpha.16"
+        "quip-apps-api": "next",
+        "quiptext": "next"
     }
 }


### PR DESCRIPTION
Previously Quip would initialize apps at build 1, version 0.1.0 - this meant that the first visible version (since it has to be published AFTER the auto-created first version) would be v0.1.1, build 2. This was confusing to beta testers, so this commit (and a corresponding change in the Quip API) makes it so that the first version you see in the dev console after running init is version 0.1.0, build 1.

This also moves us to use the next tag for Quip dependencies in templates, which I'll update to a specific version once we GA.

Fixes https://github.com/quip/quip-apps/issues/167