### PR TITLE
Windows compat

### DIFF
--- a/packages/quip-cli/src/commands/bump.ts
+++ b/packages/quip-cli/src/commands/bump.ts
@@ -61,7 +61,7 @@ export const bump = async (
     if (!noGit) {
         // stage manifest.json since we want the increment to be part of our version tag
         try {
-            await runCmd(dir, "git", "add", manifestPath);
+            await runCmdPromise(dir, "git", "add", manifestPath);
         } catch (e) {
             // silent failure ok here, since it just means we're not using git
         }

--- a/packages/quip-cli/src/commands/bump.ts
+++ b/packages/quip-cli/src/commands/bump.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 import fs from "fs";
 import path from "path";
 import semver, { ReleaseType } from "semver";
+import { NPM_BINARY_NAME } from "../lib/config";
 import { findManifest, getManifest, writeManifest } from "../lib/manifest";
 import { println } from "../lib/print";
 import { runCmd, runCmdPromise } from "../lib/util";
@@ -75,7 +76,14 @@ export const bump = async (
         extraArgs.push("--git-tag-version", "false");
     }
     // run with --force since we will have a dirty tree (cause we added manifest.json above)
-    await runCmd(dir, "npm", "version", "--force", version, ...extraArgs);
+    await runCmd(
+        dir,
+        NPM_BINARY_NAME,
+        "version",
+        "--force",
+        version,
+        ...extraArgs
+    );
     if (!silent) {
         println(
             chalk`{magenta Successfully updated ${manifest.name} v${manifest.version_name} (${manifest.version_number})}`

--- a/packages/quip-cli/src/commands/init.ts
+++ b/packages/quip-cli/src/commands/init.ts
@@ -4,7 +4,11 @@ import fs from "fs";
 import inquirer from "inquirer";
 import path from "path";
 import cliAPI, { successOnly } from "../lib/cli-api";
-import { defaultConfigPath, DEFAULT_SITE } from "../lib/config";
+import {
+    defaultConfigPath,
+    DEFAULT_SITE,
+    NPM_BINARY_NAME,
+} from "../lib/config";
 import { print, println } from "../lib/print";
 import { Manifest } from "../lib/types";
 import { copy, runCmd } from "../lib/util";
@@ -350,13 +354,13 @@ export default class Init extends Command {
             );
             // npm install
             println(chalk`{green installing dependencies...}`);
-            await runCmd(appDir, "npm", "install");
+            await runCmd(appDir, NPM_BINARY_NAME, "install");
             // bump the version since we already have a version 0 in the console
             println(chalk`{green bumping version...}`);
             await bump(appDir, "minor", { silent: flags.json });
             // npm run build
             println(chalk`{green building app...}`);
-            await runCmd(appDir, "npm", "run", "build");
+            await runCmd(appDir, NPM_BINARY_NAME, "run", "build");
             // then publish the new version
             println(chalk`{green uploading bundle...}`);
             const newManifest = await doPublish(

--- a/packages/quip-cli/src/lib/config.ts
+++ b/packages/quip-cli/src/lib/config.ts
@@ -5,6 +5,9 @@ import { pathExists } from "./util";
 
 export const DEFAULT_SITE = "quip.com";
 export const SKIP_SSL_FOR_SITES = new Set(["quip.codes"]);
+export const NPM_BINARY_NAME = /^win/.test(process.platform)
+    ? "npm.cmd"
+    : "npm";
 
 interface QLAConfigSite {
     accessToken: string;

--- a/packages/quip-cli/src/lib/manifest.ts
+++ b/packages/quip-cli/src/lib/manifest.ts
@@ -21,7 +21,7 @@ export const findManifest = async (
             closestManifest = file;
         }
     }
-    return closestManifest;
+    return closestManifest ? path.join(dir, closestManifest) : undefined;
 };
 
 interface FormattingInfo {


### PR DESCRIPTION
- use npm.cmd rather than just npm when invoking npm via a subprocess in windows

Should fix https://github.com/quip/quip-apps/issues/182 (which I think is misdiagnosed)

- Fixes a regression in the path returned by findManifest (which became relative but needs to be absolute)
- Fixes a bug where when git wasn't installed init would fail (which was supposed to fail silently but was exiting the program)