### PR TITLE
Enable source maps in dev in our templates

### DIFF
--- a/packages/quip-apps-api/src/client.ts
+++ b/packages/quip-apps-api/src/client.ts
@@ -21,7 +21,7 @@ export interface InitializationParameters {
     initOptions?: string;
     initOptionsSource?: string;
     creationBlobs?: Blob[];
-    creationSource: string;
+    creationSource: CreationSource;
 }
 
 export interface BlobWithThumbnails {

--- a/packages/quip-cli/templates/js_webpack/package.json
+++ b/packages/quip-cli/templates/js_webpack/package.json
@@ -4,7 +4,7 @@
     "description": "Quip Live App Boilerplate",
     "license": "UNLICENSED",
     "scripts": {
-        "start": "webpack-dev-server --https",
+        "start": "NODE_ENV=development; webpack-dev-server --https",
         "build": "webpack",
         "test": "webpack && jest --silent",
         "test:watch": "npm test -- --watch",

--- a/packages/quip-cli/templates/ts_webpack/package.json
+++ b/packages/quip-cli/templates/ts_webpack/package.json
@@ -4,7 +4,7 @@
     "description": "Quip Live App Boilerplate",
     "license": "UNLICENSED",
     "scripts": {
-        "start": "webpack-dev-server --https",
+        "start": "NODE_ENV=development; webpack-dev-server --https",
         "build": "webpack",
         "test": "webpack && jest --silent",
         "test:watch": "npm test -- --watch",


### PR DESCRIPTION
This seems like a no brainer but PRing in case we'd like to change the approach