### PR TITLE
quip-cli: fix bug to release build version argument

### DIFF
--- a/packages/quip-cli/src/commands/release.ts
+++ b/packages/quip-cli/src/commands/release.ts
@@ -79,7 +79,7 @@ export default class Release extends Command {
 
     static args = [
         {
-            name: "build number",
+            name: "build",
             description: "the build number to release",
             parse: (arg: string) => parseInt(arg),
         },


### PR DESCRIPTION
Currently the `quip-cli release --beta [BUILD_VERSION]` doesn't work with the `[BUILD_VERSION]` argument, meaning that the command can only be used interactively.

This PR addresses the bug and allows to use the command in a CI/CD pipeline.