### PR TITLE
Enable quip-cli with --with-token option

### DIFF
--- a/packages/quip-cli/README.md
+++ b/packages/quip-cli/README.md
@@ -123,9 +123,10 @@ USAGE
   $ qla login
 
 OPTIONS
-  -f, --force      forces a re-login even if a user is currently logged in
-  -h, --help       show CLI help
-  -s, --site=site  [default: quip.com] use a specific quip site rather than the standard quip.com login
+  -f, --force                  forces a re-login even if a user is currently logged in
+  -h, --help                   show CLI help
+  -s, --site=site              [default: quip.com] use a specific quip site rather than the standard quip.com login
+  -t, --with-token=with-token  log in with a given access token instead of interactive web login redirect
 ```
 
 _See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v0.1.2/src/commands/login.ts)_

--- a/packages/quip-cli/README.md
+++ b/packages/quip-cli/README.md
@@ -123,10 +123,10 @@ USAGE
   $ qla login
 
 OPTIONS
-  -f, --force                  forces a re-login even if a user is currently logged in
-  -h, --help                   show CLI help
-  -s, --site=site              [default: quip.com] use a specific quip site rather than the standard quip.com login
-  -t, --with-token=with-token  log in with a given access token instead of interactive web login redirect
+  -f, --force             forces a re-login even if a user is currently logged in
+  -h, --help              show CLI help
+  -s, --site=site         [default: quip.com] use a specific quip site rather than the standard quip.com login
+  -t, --with-token=token  log in with a given access token instead of interactive web login redirect
 ```
 
 _See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v0.1.2/src/commands/login.ts)_

--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -142,6 +142,7 @@ export default class Login extends Command {
             char: "t",
             description:
                 "log in with a given access token instead of interactive web login redirect",
+            helpValue: "token",
         }),
         port: flags.integer({
             hidden: true,

--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -175,9 +175,9 @@ export default class Login extends Command {
         const { site, force, hostname, port, config } = flags;
         const accessToken = flags["with-token"];
 
-        // displays error message if command has part as "--with-token=" without passing a value.
-        if (typeof accessToken !== 'undefined' && accessToken === "") {
-            this.error("Token cannot be empty, please provide a valid token.", {exit: false});
+        // displays error message if command has "--with-token" flag without passing a value.
+        if (accessToken === "") {
+            this.error("Flag --with-token expects a value.");
             return;
         }
 

--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -175,6 +175,12 @@ export default class Login extends Command {
         const { site, force, hostname, port, config } = flags;
         const accessToken = flags["with-token"];
 
+        // displays error message if command has part as "--with-token=" without passing a value.
+        if (typeof accessToken !== 'undefined' && accessToken === "") {
+            this.error("Token cannot be empty, please provide a valid token.", {exit: false});
+            return;
+        }
+
         if (!force && (await isLoggedIn(config, site))) {
             let alt = "";
             if (site === DEFAULT_SITE) {

--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -138,6 +138,11 @@ export default class Login extends Command {
                 "use a specific quip site rather than the standard quip.com login",
             default: DEFAULT_SITE,
         }),
+        "with-token": flags.string({
+            char: "t",
+            description:
+                "log in with a given access token instead of interactive web login redirect",
+        }),
         port: flags.integer({
             hidden: true,
             description:
@@ -168,6 +173,7 @@ export default class Login extends Command {
         const { flags } = this.parse(Login);
 
         const { site, force, hostname, port, config } = flags;
+        const accessToken = flags["with-token"];
 
         if (!force && (await isLoggedIn(config, site))) {
             let alt = "";
@@ -181,7 +187,11 @@ export default class Login extends Command {
         }
 
         try {
-            await login({ site, hostname, port, config });
+            if (accessToken) {
+                await writeSiteConfig(config, site, { accessToken });
+            } else {
+                await login({ site, hostname, port, config });
+            }
             this.log("Successfully logged in.");
         } catch (e) {
             this.error(e);

--- a/packages/quip-cli/src/lib/config.ts
+++ b/packages/quip-cli/src/lib/config.ts
@@ -28,7 +28,7 @@ export const writeSiteConfig = async (
 ) => {
     const qlaConfig = await readConfig(configPath);
     qlaConfig.sites[site] = config;
-    writeConfig(configPath, qlaConfig);
+    await writeConfig(configPath, qlaConfig);
 };
 
 const writeConfig = (configPath: string, config: QLAConfig) => {

--- a/packages/quip-cli/test/login.test.ts
+++ b/packages/quip-cli/test/login.test.ts
@@ -258,4 +258,42 @@ describe("qla login", () => {
                 );
             });
     });
+    describe("login with access token", async () => {
+        oclifTest
+            .stdout()
+            .command(["login", "--force", "--with-token", "FAKE-ACCESS-TOKEN"])
+            .it(
+                "logs in with custom access token when passing --with-token",
+                async () => {
+                    expect(mockedOpen).not.toHaveBeenCalled();
+                    expect(mockedCallAPI).not.toHaveBeenCalled();
+                    const config = (await fs.promises.readFile(
+                        path.join(homedir, ".quiprc"),
+                        "utf-8"
+                    )) as string;
+                    expect(config).toMatchInlineSnapshot(`
+                        "{
+                          \\"sites\\": {
+                            \\"quip.com\\": {
+                              \\"accessToken\\": \\"FAKE-ACCESS-TOKEN\\"
+                            },
+                            \\"quip.codes\\": {
+                              \\"accessToken\\": \\"hello\\"
+                            }
+                          }
+                        }"
+                    `);
+                }
+            );
+    });
+    oclifTest
+        .stdout()
+        .command(["login", "--with-token", "FAKE-ACCESS-TOKEN"])
+        .it("Doesn't log in if you're already logged in", async (ctx) => {
+            expect(ctx.stdout).toMatchInlineSnapshot(`
+                    "You're already logged in to quip.com. Pass --force to log in again or --site to log in to a different site.
+                    "
+                `);
+            expect(mockedOpen).not.toHaveBeenCalled();
+        });
 });

--- a/packages/quip-cli/test/login.test.ts
+++ b/packages/quip-cli/test/login.test.ts
@@ -59,6 +59,19 @@ jest.mock("../src/lib/cli-api");
 const mockedCallAPI = (callAPI as unknown) as jest.Mock<Promise<any>>;
 const mockGetStateString = (getStateString as unknown) as jest.Mock<string>;
 mockGetStateString.mockImplementation(() => "state1234");
+const readQuiprcContent = async () => {
+    const rcPath = path.join(homedir, ".quiprc");
+    expect(await pathExists(rcPath)).toBe(true);
+    const configStr = (await fs.promises.readFile(
+        rcPath,
+        "utf-8"
+    )) as string;
+    let parsed = {};
+    expect(() => {
+        parsed = JSON.parse(configStr);
+    }).not.toThrowError();
+    return parsed;
+};
 
 describe("qla login", () => {
     let configSpy: jest.SpyInstance;
@@ -112,17 +125,7 @@ describe("qla login", () => {
                         redirect_uri: "http%3A%2F%2F127.0.0.1%3A9898",
                     }
                 );
-                const rcPath = path.join(homedir, ".quiprc");
-                expect(await pathExists(rcPath)).toBe(true);
-                const configStr = (await fs.promises.readFile(
-                    rcPath,
-                    "utf-8"
-                )) as string;
-                let parsed = {};
-                expect(() => {
-                    parsed = JSON.parse(configStr);
-                }).not.toThrowError();
-                expect(parsed).toMatchInlineSnapshot(`
+                expect(await readQuiprcContent()).toMatchInlineSnapshot(`
                     Object {
                       "sites": Object {
                         "quip.com": Object {
@@ -258,7 +261,7 @@ describe("qla login", () => {
                 );
             });
     });
-    describe("login with access token", async () => {
+    describe("login with access token", () => {
         oclifTest
             .stdout()
             .command(["login", "--force", "--with-token", "FAKE-ACCESS-TOKEN"])
@@ -267,22 +270,18 @@ describe("qla login", () => {
                 async () => {
                     expect(mockedOpen).not.toHaveBeenCalled();
                     expect(mockedCallAPI).not.toHaveBeenCalled();
-                    const config = (await fs.promises.readFile(
-                        path.join(homedir, ".quiprc"),
-                        "utf-8"
-                    )) as string;
-                    expect(config).toMatchInlineSnapshot(`
-                        "{
-                          \\"sites\\": {
-                            \\"quip.com\\": {
-                              \\"accessToken\\": \\"FAKE-ACCESS-TOKEN\\"
-                            },
-                            \\"quip.codes\\": {
-                              \\"accessToken\\": \\"hello\\"
-                            }
-                          }
-                        }"
-                    `);
+                    expect(await readQuiprcContent()).toMatchInlineSnapshot(`
+                    Object {
+                      "sites": Object {
+                        "quip.codes": Object {
+                          "accessToken": "hello",
+                        },
+                        "quip.com": Object {
+                          "accessToken": "FAKE-ACCESS-TOKEN",
+                        },
+                      },
+                    }
+                `);
                 }
             );
     });

--- a/packages/quip-cli/test/login.test.ts
+++ b/packages/quip-cli/test/login.test.ts
@@ -300,7 +300,7 @@ describe("qla login", () => {
         .stdout()
         .command(["login", "--with-token="])
         .catch(err => {
-            expect(err.message).toContain("Flag --with-token expects a value.");
+            expect(err.message).toEqual("Flag --with-token expects a value.");
         })
         .it("stdout displays nothing when empty token is provided", (ctx) => {
             expect(ctx.stdout).toEqual("");

--- a/packages/quip-cli/test/login.test.ts
+++ b/packages/quip-cli/test/login.test.ts
@@ -288,11 +288,22 @@ describe("qla login", () => {
     oclifTest
         .stdout()
         .command(["login", "--with-token", "FAKE-ACCESS-TOKEN"])
-        .it("Doesn't log in if you're already logged in", async (ctx) => {
+        .it("Doesn't log in if you're already logged in", (ctx) => {
             expect(ctx.stdout).toMatchInlineSnapshot(`
                     "You're already logged in to quip.com. Pass --force to log in again or --site to log in to a different site.
                     "
                 `);
+            expect(mockedOpen).not.toHaveBeenCalled();
+        });
+
+    oclifTest
+        .stdout()
+        .command(["login", "--with-token="])
+        .catch(err => {
+            expect(err.message).toContain("Flag --with-token expects a value.");
+        })
+        .it("stdout displays nothing when empty token is provided", (ctx) => {
+            expect(ctx.stdout).toEqual("");
             expect(mockedOpen).not.toHaveBeenCalled();
         });
 });


### PR DESCRIPTION
**Subject**: [new feature] Enable quip-cli with `--with-token` option


**Body**: With `--with-token` option, user does not need to log in with interactive web interface. This will be helpful to set up CI/CD jobs.

**Has a test been added?**: Yes

**Reviewers**: @FlikHu @gaspar09 