### PR TITLE
Add `export` option to login command to display token on Terminal

### DIFF
--- a/packages/quip-cli/README.md
+++ b/packages/quip-cli/README.md
@@ -132,8 +132,9 @@ USAGE
   $ quip-cli login
 
 OPTIONS
-  -e, --export            Display token in terminal after login without storing it in config file.
-                          NOTE: this cannot work with `--with-token` together.
+  -e, --export            Get a new access token with login, then display the token in the terminal without storing it
+                          in the config file.
+                          Note: You can’t use both the `--export` and `--with-token` options in the same command.
 
   -f, --force             forces a re-login even if a user is currently logged in
 

--- a/packages/quip-cli/README.md
+++ b/packages/quip-cli/README.md
@@ -132,7 +132,7 @@ USAGE
   $ quip-cli login
 
 OPTIONS
-  -e, --export            Display token in terminal after login without store it in config file.
+  -e, --export            Display token in terminal after login without storing it in config file.
                           NOTE: this cannot work with `--with-token` together.
 
   -f, --force             forces a re-login even if a user is currently logged in

--- a/packages/quip-cli/README.md
+++ b/packages/quip-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g quip-cli
 $ quip-cli COMMAND
 running command...
 $ quip-cli (-v|--version|version)
-quip-cli/0.2.0-alpha.36 darwin-x64 node-v14.18.1
+quip-cli/0.2.0-alpha.37 darwin-x64 node-v14.18.1
 $ quip-cli --help [COMMAND]
 USAGE
   $ quip-cli COMMAND
@@ -57,7 +57,7 @@ OPTIONS
   -v, --version=version  which version to show the details for. Only useful with --id
 ```
 
-_See code: [src/commands/apps.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.36/src/commands/apps.ts)_
+_See code: [src/commands/apps.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/apps.ts)_
 
 ## `quip-cli bump [INCREMENT]`
 
@@ -83,7 +83,7 @@ OPTIONS
                                          integer
 ```
 
-_See code: [src/commands/bump.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.36/src/commands/bump.ts)_
+_See code: [src/commands/bump.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/bump.ts)_
 
 ## `quip-cli help [COMMAND]`
 
@@ -121,7 +121,7 @@ OPTIONS
   --no-release     don't release the initial version (leave app uninstallable and in the "unreleased" state)
 ```
 
-_See code: [src/commands/init.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.36/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/init.ts)_
 
 ## `quip-cli login`
 
@@ -132,15 +132,20 @@ USAGE
   $ quip-cli login
 
 OPTIONS
+  -e, --export            Display token in terminal after login without store it in config file.
+                          NOTE: this cannot work with `--with-token` together.
+
   -f, --force             forces a re-login even if a user is currently logged in
+
   -h, --help              show CLI help
+
   -s, --site=site         [default: quip.com] use a specific quip site rather than the standard quip.com login
 
   -t, --with-token=token  log in users with your specified access token instead of redirecting to a login page.
                           SEE ALSO: https://quip.com/dev/automation/documentation/current#tag/Authentication
 ```
 
-_See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.36/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/login.ts)_
 
 ## `quip-cli migration [NAME]`
 
@@ -162,7 +167,7 @@ OPTIONS
                          in the manifest
 ```
 
-_See code: [src/commands/migration.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.36/src/commands/migration.ts)_
+_See code: [src/commands/migration.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/migration.ts)_
 
 ## `quip-cli publish`
 
@@ -179,7 +184,7 @@ OPTIONS
   -s, --site=site      [default: quip.com] use a specific quip site rather than the standard quip.com login
 ```
 
-_See code: [src/commands/publish.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.36/src/commands/publish.ts)_
+_See code: [src/commands/publish.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/publish.ts)_
 
 ## `quip-cli release [BUILD]`
 
@@ -200,5 +205,5 @@ OPTIONS
   -s, --site=site  [default: quip.com] use a specific quip site rather than the standard quip.com login
 ```
 
-_See code: [src/commands/release.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.36/src/commands/release.ts)_
+_See code: [src/commands/release.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/release.ts)_
 <!-- commandsstop -->

--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -155,7 +155,7 @@ export default class Login extends Command {
             char: "e",
             description:
                 "Display token in terminal after login without storing it in config file.\n" +
-                "NOTE: this cannot work with `--with-token` together.",
+                "Note: You can’t use both the `--export` and `--with-token` options in the same command.",
         }),
         port: flags.integer({
             hidden: true,

--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -154,7 +154,7 @@ export default class Login extends Command {
         export: flags.boolean({
             char: "e",
             description:
-                "Display token in terminal after login without storing it in config file.\n" +
+                "Get a new access token with login, then display the token in the terminal without storing it in the config file.\n" +
                 "Note: You can’t use both the `--export` and `--with-token` options in the same command.",
         }),
         port: flags.integer({

--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -158,7 +158,7 @@ export default class Login extends Command {
         export: flags.boolean({
             char: "e",
             description:
-                "Display token in terminal after login without store it in config file.\n" +
+                "Display token in terminal after login without storing it in config file.\n" +
                 "NOTE: this cannot work with `--with-token` together.",
         }),
         port: flags.integer({
@@ -201,7 +201,7 @@ export default class Login extends Command {
         }
 
         if (accessToken !== undefined && displayTokenOnly) {
-            this.error("Flags --with-token and --export cannot work together.");
+            this.error("Flags --with-token and --export cannot be used together.");
             return;
         }
 

--- a/packages/quip-cli/src/commands/login.ts
+++ b/packages/quip-cli/src/commands/login.ts
@@ -68,12 +68,15 @@ export const login = async ({
     port = DEFAULT_PORT,
     config = defaultConfigPath(),
     displayTokenOnly = false,
+    // This is added for test purpose, otherwise the mock will have problem to fetch data from stdout.
+    log = console.log
 }: {
     site: string;
     hostname?: string;
     port?: number;
     config?: string;
     displayTokenOnly?: boolean;
+    log?: (message?: string, ...args: any[])=> void
 }): Promise<void> => {
     const { code_challenge, code_verifier } = pkceChallenge(43);
     const state = getStateString();
@@ -123,9 +126,9 @@ export const login = async ({
         );
     }
     if (displayTokenOnly) {
-        println(chalk`{magenta Your access token is "${accessToken}".}`);
+        log(chalk`{magenta Your access token is "${accessToken}".}`);
     } else {
-        await writeSiteConfig(config, site, {accessToken});
+        await writeSiteConfig(config, site, { accessToken });
     }
 };
 
@@ -217,7 +220,8 @@ export default class Login extends Command {
             if (accessToken) {
                 await writeSiteConfig(config, site, { accessToken });
             } else {
-                await login({ site, hostname, port, config, displayTokenOnly });
+                const log = this.log;
+                await login({ site, hostname, port, config, displayTokenOnly, log });
             }
             !displayTokenOnly && this.log("Successfully logged in.");
         } catch (e) {

--- a/packages/quip-cli/test/login.test.ts
+++ b/packages/quip-cli/test/login.test.ts
@@ -303,7 +303,7 @@ describe("qla login", () => {
         .stdout()
         .command(["login", "--with-token", "FAKE-ACCESS-TOKEN", "--export"])
         .catch(err => {
-            expect(err.message).toEqual("Flags --with-token and --export cannot work together.");
+            expect(err.message).toEqual("Flags --with-token and --export cannot be used together.");
         })
         .it("Flags conflict between --with-token and --export", (ctx) => {
             expect(ctx.stdout).toEqual("");

--- a/packages/quip-cli/test/login.test.ts
+++ b/packages/quip-cli/test/login.test.ts
@@ -160,18 +160,14 @@ describe("qla login", () => {
                 async (ctx) => {
                     expect(mockedOpen).toHaveBeenCalled();
                     expect(mockedCallAPI).toHaveBeenCalled();
-                    const config = (await fs.promises.readFile(
-                        path.join(homedir, ".quiprc"),
-                        "utf-8"
-                    )) as string;
-                    expect(config).toMatchInlineSnapshot(`
-                        "{
-                          \\"sites\\": {
-                            \\"quip.com\\": {
-                              \\"accessToken\\": \\"another-token\\"
-                            }
-                          }
-                        }"
+                    expect(await readQuiprcContent()).toMatchInlineSnapshot(`
+                        Object {
+                          "sites": Object {
+                            "quip.com": Object {
+                              "accessToken": "another-token",
+                            },
+                          },
+                        }
                     `);
                 }
             );
@@ -204,21 +200,17 @@ describe("qla login", () => {
                         redirect_uri: "http%3A%2F%2F127.0.0.1%3A9898",
                     }
                 );
-                const config = (await fs.promises.readFile(
-                    path.join(homedir, ".quiprc"),
-                    "utf-8"
-                )) as string;
-                expect(config).toMatchInlineSnapshot(`
-                    "{
-                      \\"sites\\": {
-                        \\"quip.com\\": {
-                          \\"accessToken\\": \\"another-token\\"
+                expect(await readQuiprcContent()).toMatchInlineSnapshot(`
+                    Object {
+                      "sites": Object {
+                        "quip.codes": Object {
+                          "accessToken": "hello",
                         },
-                        \\"quip.codes\\": {
-                          \\"accessToken\\": \\"hello\\"
-                        }
-                      }
-                    }"
+                        "quip.com": Object {
+                          "accessToken": "another-token",
+                        },
+                      },
+                    }
                 `);
             });
         oclifTest
@@ -306,4 +298,45 @@ describe("qla login", () => {
             expect(ctx.stdout).toEqual("");
             expect(mockedOpen).not.toHaveBeenCalled();
         });
+
+    oclifTest
+        .stdout()
+        .command(["login", "--with-token", "FAKE-ACCESS-TOKEN", "--export"])
+        .catch(err => {
+            expect(err.message).toEqual("Flags --with-token and --export cannot work together.");
+        })
+        .it("Flags conflict between --with-token and --export", (ctx) => {
+            expect(ctx.stdout).toEqual("");
+            expect(mockedOpen).not.toHaveBeenCalled();
+        });
+
+    oclifTest
+        .stdout()
+        .do(() => {
+            redirectToUrl("/?code=some-code&state=state1234");
+            mockedCallAPI.mockResolvedValueOnce({
+                access_token: "display-only-token",
+                token_type: "Bearer",
+            });
+        })
+        .command(["login", "--export"])
+        .it("Display token in terminal only", async (ctx) => {
+            expect(ctx.stdout).toContain('Your access token is "display-only-token".');
+            expect(mockedOpen).toHaveBeenCalled();
+            expect(mockedCallAPI).toHaveBeenCalled();
+            // The display-only token will not be stored to local config file.
+            expect(await readQuiprcContent()).toMatchInlineSnapshot(`
+                    Object {
+                      "sites": Object {
+                        "quip.codes": Object {
+                          "accessToken": "hello",
+                        },
+                        "quip.com": Object {
+                          "accessToken": "FAKE-ACCESS-TOKEN",
+                        },
+                      },
+                    }
+                `);
+        });
+
 });


### PR DESCRIPTION
Add option to quip-cli login command to display token on Terminal rather than store it in .quiprc (--export)

Has a test been added?: Yes