### PR TITLE
Remove app.js from dist folder after publishing successfully

### DIFF
--- a/packages/quip-cli/README.md
+++ b/packages/quip-cli/README.md
@@ -21,7 +21,7 @@ $ npm install -g quip-cli
 $ quip-cli COMMAND
 running command...
 $ quip-cli (-v|--version|version)
-quip-cli/0.2.0-alpha.37 darwin-x64 node-v14.18.1
+quip-cli/0.2.0-alpha.38 darwin-x64 node-v14.18.1
 $ quip-cli --help [COMMAND]
 USAGE
   $ quip-cli COMMAND
@@ -57,7 +57,7 @@ OPTIONS
   -v, --version=version  which version to show the details for. Only useful with --id
 ```
 
-_See code: [src/commands/apps.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/apps.ts)_
+_See code: [src/commands/apps.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.38/src/commands/apps.ts)_
 
 ## `quip-cli bump [INCREMENT]`
 
@@ -83,7 +83,7 @@ OPTIONS
                                          integer
 ```
 
-_See code: [src/commands/bump.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/bump.ts)_
+_See code: [src/commands/bump.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.38/src/commands/bump.ts)_
 
 ## `quip-cli help [COMMAND]`
 
@@ -121,7 +121,7 @@ OPTIONS
   --no-release     don't release the initial version (leave app uninstallable and in the "unreleased" state)
 ```
 
-_See code: [src/commands/init.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/init.ts)_
+_See code: [src/commands/init.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.38/src/commands/init.ts)_
 
 ## `quip-cli login`
 
@@ -146,7 +146,7 @@ OPTIONS
                           SEE ALSO: https://quip.com/dev/automation/documentation/current#tag/Authentication
 ```
 
-_See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.38/src/commands/login.ts)_
 
 ## `quip-cli migration [NAME]`
 
@@ -168,7 +168,7 @@ OPTIONS
                          in the manifest
 ```
 
-_See code: [src/commands/migration.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/migration.ts)_
+_See code: [src/commands/migration.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.38/src/commands/migration.ts)_
 
 ## `quip-cli publish`
 
@@ -185,7 +185,7 @@ OPTIONS
   -s, --site=site      [default: quip.com] use a specific quip site rather than the standard quip.com login
 ```
 
-_See code: [src/commands/publish.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/publish.ts)_
+_See code: [src/commands/publish.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.38/src/commands/publish.ts)_
 
 ## `quip-cli release [BUILD]`
 
@@ -206,5 +206,5 @@ OPTIONS
   -s, --site=site  [default: quip.com] use a specific quip site rather than the standard quip.com login
 ```
 
-_See code: [src/commands/release.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.37/src/commands/release.ts)_
+_See code: [src/commands/release.ts](https://github.com/quip/quip-apps/blob/v0.2.0-alpha.38/src/commands/release.ts)_
 <!-- commandsstop -->

--- a/packages/quip-cli/src/commands/publish.ts
+++ b/packages/quip-cli/src/commands/publish.ts
@@ -6,7 +6,7 @@ import minimatch from "minimatch";
 import path from "path";
 import crypto from "crypto";
 import cliAPI, { successOnly } from "../lib/cli-api";
-import { defaultConfigPath, DEFAULT_SITE } from "../lib/config";
+import { DEFAULT_SITE, defaultConfigPath } from "../lib/config";
 import { findManifest, getManifest } from "../lib/manifest";
 import { println } from "../lib/print";
 import { isMigration, Manifest, Migration } from "../lib/types";
@@ -190,6 +190,12 @@ export default class Publish extends Command {
                 println(
                     chalk`{magenta Successfully published ${manifest.name} v${manifest.version_name} (${manifest.version_number})}`
                 );
+                let entryJsFile = "dist/app.js";
+                if (manifest.js_files?.length === 1) {
+                    entryJsFile = manifest.js_files[0];
+                }
+                const entryJsPath = path.join(process.cwd(), entryJsFile);
+                fs.existsSync(entryJsPath) && fs.unlinkSync(entryJsPath);
             }
         } else {
             if (!flags.json) {

--- a/packages/quip-cli/src/commands/publish.ts
+++ b/packages/quip-cli/src/commands/publish.ts
@@ -48,7 +48,7 @@ export const createBundle = async (
         if (!files) {
             return;
         }
-        files.forEach(matcher => {
+        files.forEach((matcher) => {
             if (isMigration(matcher)) {
                 addToFiles(matcher.js_file, source);
             } else {
@@ -92,25 +92,26 @@ export const doPublish = async (
         ignore
     );
     if (missing.size > 0) {
-        println(chalk`{red WARNING: the following files were defined in your manifest, but were not found.}
+        println(chalk`{yellow WARNING: the following files were defined in your manifest, but were not found.}
 {red This bundle may be incomplete, you should include these files or remove them from your manifest.}`);
         for (let [source, files] of missing) {
-            println(chalk`{red === ${source} ===}`);
-            files.forEach(f => println(chalk`{red ${f}}`));
+            println(chalk`{yellow === ${source} ===}`);
+            files.forEach((f) => println(chalk`{yellow ${f}}`));
         }
+        println(
+            chalk`{green Note: If only app.js is missing, please try to compile the live app by running \`npm run build\` and try publishing again.}`
+        );
+        return null;
     }
     const files = await Promise.all<[string, Buffer, string]>(
-        bundle.map(async name => {
+        bundle.map(async (name) => {
             const fileBuffer = await fs.promises.readFile(
                 path.join(root, name)
             );
             return [
                 name,
                 fileBuffer,
-                crypto
-                    .createHash("md5")
-                    .update(fileBuffer)
-                    .digest("hex"),
+                crypto.createHash("md5").update(fileBuffer).digest("hex"),
             ] as [string, Buffer, string];
         })
     );
@@ -192,7 +193,7 @@ export default class Publish extends Command {
             }
         } else {
             if (!flags.json) {
-                println(chalk`{red Publishing failed.}`);
+                println(chalk`{red \nPublishing failed.}`);
             }
             process.exit(1);
         }

--- a/packages/quip-cli/src/commands/publish.ts
+++ b/packages/quip-cli/src/commands/publish.ts
@@ -95,11 +95,11 @@ export const doPublish = async (
         println(chalk`{yellow WARNING: the following files were defined in your manifest, but were not found.}
 {red This bundle may be incomplete, you should include these files or remove them from your manifest.}`);
         for (let [source, files] of missing) {
-            println(chalk`{yellow === ${source} ===}`);
-            files.forEach((f) => println(chalk`{yellow ${f}}`));
+            println(chalk`{red === ${source} ===}`);
+            files.forEach((f) => println(chalk`{red ${f}}`));
         }
         println(
-            chalk`{green Note: If only app.js is missing, please try to compile the live app by running \`npm run build\` and try publishing again.}`
+            chalk`{yellow Note: You can’t publish a live app without compiling it first. Compile the live app by using \`npm run build\` then try publishing again.}`
         );
         return null;
     }


### PR DESCRIPTION
This will force developers to run `npm run build` before they publish new release. This will prevent developers from publish the older version more than once by mistake.

https://github.com/quip/issues/issues/20159

Has a test been added?: No