### PR TITLE
Fix for 

### DIFF
--- a/examples/power-bi/webpack.config.js
+++ b/examples/power-bi/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
         rules: [
             {
                 test: /\.[jt]sx?$/,
-                include: [/src/],
+                include: [path.resolve(__dirname, "src")],
                 use: "babel-loader",
             },
         ],

--- a/examples/tableau/webpack.config.js
+++ b/examples/tableau/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
         rules: [
             {
                 test: /\.[jt]sx?$/,
-                include: [/src/],
+                include: [path.resolve(__dirname, "src")],
                 use: "babel-loader",
             },
         ],

--- a/packages/quip-cli/templates/js_webpack/webpack.config.js
+++ b/packages/quip-cli/templates/js_webpack/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
         rules: [
             {
                 test: /\.jsx?$/,
-                include: [/src/],
+                include: [path.resolve(__dirname, "src")],
                 use: "babel-loader",
             },
         ],

--- a/packages/quip-cli/templates/ts_webpack/webpack.config.js
+++ b/packages/quip-cli/templates/ts_webpack/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
         rules: [
             {
                 test: /\.[jt]sx?$/,
-                include: [/src/],
+                include: [path.resolve(__dirname, "src")],
                 use: "babel-loader",
             },
         ],


### PR DESCRIPTION
This is a fix for https://github.com/quip/issues/issues/22285 

By not including _every_ `src` directory (many of which will exist under `./node_modules` [1]) and including only `<__dirname>/src` we avoid trying to webpack way more than we should, and avoid this problem. 

[1] a handful of `src` examples, for illustration: 
```
...
./my-second-live-app/node_modules/has/src
./my-second-live-app/node_modules/@sinonjs/fake-timers/src
./my-second-live-app/node_modules/airbnb-prop-types/src
./my-second-live-app/node_modules/@jridgewell/sourcemap-codec/src
./my-second-live-app/node_modules/@jridgewell/trace-mapping/src
...
```