### PR TITLE
Update main package-lock and publish-next workflow

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -19,7 +19,7 @@ jobs:
                   git config --local user.email "ospreyquip@gmail.com"
                   git config --local user.name "Osp Rey [CI]"
             - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-            - run: npm ci
+            - run: npm install
             - run: npm test
             - run: npm run build
             - run: ./node_modules/.bin/lerna publish --conventional-commits --conventional-prerelease --pre-dist-tag next --yes

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,6 @@
     "": {
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "package-lock.json": "^1.0.0"
-      },
       "devDependencies": {
         "babel-eslint": "^8.0.1",
         "eslint": "^4.9.0",
@@ -8009,11 +8006,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/package-lock.json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/package-lock.json/-/package-lock.json-1.0.0.tgz",
-      "integrity": "sha512-+yEXtNdlCs5N0Zy/9uvkifgf/RqnGu0WqP4j9Wu1Us4YReFe1YNBh2Krmf8B1xGxjpYnta63K55QP8bkafnOzA=="
     },
     "node_modules/parallel-transform": {
       "version": "1.2.0",


### PR DESCRIPTION
For some reason the build fails due to additional missing dependencies that should exist. This PR changes 2 things:
1. Switch to `npm install` for the `publish-next` workflow to see if the dependencies are correctly installed
2. Update the root project's `package-lock.json` to ensure it's up to date

Tested locally with `npm install && npm test && npm run build`