### PR TITLE
Add additional missing dependencies

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -19,7 +19,7 @@ jobs:
                   git config --local user.email "ospreyquip@gmail.com"
                   git config --local user.name "Osp Rey [CI]"
             - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-            - run: npm install
+            - run: npm ci
             - run: npm test
             - run: npm run build
             - run: ./node_modules/.bin/lerna publish --conventional-commits --conventional-prerelease --pre-dist-tag next --yes

--- a/packages/Chevron/package-lock.json
+++ b/packages/Chevron/package-lock.json
@@ -12,7 +12,9 @@
                 "quip-apps-webpack-config": "^0.2.1-alpha.2"
             },
             "devDependencies": {
+                "@babel/core": "^7.5.5",
                 "@babel/preset-env": "^7.5.5",
+                "@babel/preset-react": "^7.0.0",
                 "cross-env": "^7.0.3",
                 "webpack": "^5.91.0",
                 "webpack-cli": "^5.1.4"

--- a/packages/Chevron/package.json
+++ b/packages/Chevron/package.json
@@ -17,6 +17,8 @@
         "cross-env": "^7.0.3",
         "webpack-cli": "^5.1.4",
         "webpack": "^5.91.0",
-        "@babel/preset-env": "^7.5.5"
+        "@babel/core": "^7.5.5",
+        "@babel/preset-env": "^7.5.5",
+        "@babel/preset-react": "^7.0.0"
     }
 }

--- a/packages/handleRichTextBoxKeyEventNavigation/package-lock.json
+++ b/packages/handleRichTextBoxKeyEventNavigation/package-lock.json
@@ -13,7 +13,9 @@
                 "quip-apps-webpack-config": "^0.2.1-alpha.2"
             },
             "devDependencies": {
+                "@babel/core": "^7.5.5",
                 "@babel/preset-env": "^7.5.5",
+                "@babel/preset-react": "^7.0.0",
                 "cross-env": "^7.0.3",
                 "webpack-cli": "^5.1.4"
             }

--- a/packages/handleRichTextBoxKeyEventNavigation/package.json
+++ b/packages/handleRichTextBoxKeyEventNavigation/package.json
@@ -17,6 +17,8 @@
     "devDependencies": {
         "cross-env": "^7.0.3",
         "webpack-cli": "^5.1.4",
-        "@babel/preset-env": "^7.5.5"
+        "@babel/core": "^7.5.5",
+        "@babel/preset-env": "^7.5.5",
+        "@babel/preset-react": "^7.0.0"
     }
 }


### PR DESCRIPTION
Attempting to fix the build failure in the `publish-next` workflow.

- Add `@babel/core` and `@babel/preset-react` to match the webpack-config package
- Revert the `publish-next` workf flow to use `npm ci` since `npm install` did not seem to fix the build failure

Tested locally by running `npm ci && npm test && npm run build`