### PR TITLE
Remove early return statement to revert publishing behavior

### DIFF
--- a/packages/quip-cli/src/commands/publish.ts
+++ b/packages/quip-cli/src/commands/publish.ts
@@ -98,10 +98,6 @@ export const doPublish = async (
             println(chalk`{red === ${source} ===}`);
             files.forEach((f) => println(chalk`{red ${f}}`));
         }
-        println(
-            chalk`{yellow Note: You can’t publish a live app without compiling it first. Compile the live app by using \`npm run build\` then try publishing again.}`
-        );
-        return null;
     }
     const files = await Promise.all<[string, Buffer, string]>(
         bundle.map(async (name) => {


### PR DESCRIPTION
Jira ticket: https://jira.tinyspeck.com/browse/QUIPCORE-2491

Resolves an issue where the toolbar_icon file is missing (harmless) and the publishing flow fails early, blocking our live app deployment process. This PR removes the logic so that we revert back to the previous `quip-cli` behavior where we attempt to publish anyways

